### PR TITLE
[Linux] Fix minimize to tray (silent start) option

### DIFF
--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -68,6 +68,8 @@ static void my_application_activate(GApplication *application)
   gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
 
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+  // Flutter 3.24 breaks the gtk_widget_realize solution: https://github.com/leanflutter/window_manager/issues/179#issuecomment-2299534856
+  gtk_widget_hide(GTK_WIDGET(window));
 
   gtk_widget_grab_focus(GTK_WIDGET(view));
   
@@ -137,6 +139,6 @@ MyApplication *my_application_new()
 {
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID,
-                                     "flags", G_APPLICATION_FLAGS_NONE,
+                                     "flags", G_APPLICATION_DEFAULT_FLAGS,
                                      nullptr));
 }


### PR DESCRIPTION
According to the `window_manager` [documentation](https://pub.dev/packages/window_manager#hidden-at-launch), to start a window in hidden mode, we need to use `gtk_widget_realize` instead of `gtk_widget_show` to create the window widget. But since Flutter 3.24, this is broken (I checked and it is indeed broken) https://github.com/leanflutter/window_manager/issues/179#issuecomment-2299534856. The solution is to call `gtk_widget_hide` immediately after calling `fl_register_plugins`. In this case, the window is correctly minimized. I demonstrated the window operation with and without the minimize to tray option on the video (build and run steps are cut off).

https://github.com/user-attachments/assets/0f76da9a-84b9-4d81-9b16-dc1580ecce8d

Close #1437 
