### PR TITLE
Profile Tile InkWell Overflow Fix

### DIFF
--- a/lib/features/profile/widget/profile_tile.dart
+++ b/lib/features/profile/widget/profile_tile.dart
@@ -61,6 +61,7 @@ class ProfileTile extends HookConsumerWidget {
         side: BorderSide(color: effectiveOutlineColor),
         borderRadius: BorderRadius.circular(16),
       ),
+      clipBehavior: Clip.antiAlias,
       shadowColor: Colors.transparent,
       child: IntrinsicHeight(
         child: Row(


### PR DESCRIPTION
Fixed the overflow issue with the InkWell in the profile tile, making it more aesthetically pleasing.

before:
![Snipaste_2024-11-07_15-32-36](https://github.com/user-attachments/assets/4efea02c-816a-4b01-a90f-e3a0afc1de7f)

after:
![Snipaste_2024-11-07_15-33-05](https://github.com/user-attachments/assets/76892284-56b1-4558-b0af-d88f5f03d206)


There are similar issues elsewhere in the iOS Store 2.7.0 dev, but I couldn't find the corresponding code. I look forward to getting them fixed.

![图片](https://github.com/user-attachments/assets/0f87b7aa-67d4-4d66-88dd-6c0d4fae1678)

