### PR TITLE
Fix Linux build on glib < 2.74

### DIFF
--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -139,6 +139,6 @@ MyApplication *my_application_new()
 {
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID,
-                                     "flags", G_APPLICATION_DEFAULT_FLAGS,
+                                     "flags", 0,
                                      nullptr));
 }


### PR DESCRIPTION
`G_APPLICATION_DEFAULT_FLAGS` appears on `glib` 2.74, but earlier versions used the `G_APPLICATION_FLAGS_NONE` flag, so it would be logical to just use `0` to avoid breaking compatibility with older versions of `glib` (I encountered this when building Github Actions).