### PR TITLE
[CI] Fix test job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,9 @@ jobs:
           cache: true
           
       - name: Prepare
-        run: make linux-prepare
+        run: |
+          make linux-prepare
+          sudo apt update && sudo apt install libsqlite3-dev -y
       - name: Test
         run: flutter test
 


### PR DESCRIPTION
For correct operation of `sqlite` tests, `libsqlite3-dev` must be present on the Linux machine.