### PR TITLE
Fix: Support VPN modes on MacOS without hacks with osascript

### DIFF
--- a/lib/core/analytics/analytics_filter.dart
+++ b/lib/core/analytics/analytics_filter.dart
@@ -5,7 +5,7 @@ import 'package:hiddify/core/model/failures.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
-FutureOr<SentryEvent?> sentryBeforeSend(SentryEvent event, {Hint? hint}) {
+FutureOr<SentryEvent?> sentryBeforeSend(SentryEvent event, Hint? hint) {
   if (!canSendEvent(event.throwable)) return null;
   return event.copyWith(
     user: SentryUser(email: "", username: "", ipAddress: "0.0.0.0"),

--- a/lib/features/connection/data/connection_platform_source.dart
+++ b/lib/features/connection/data/connection_platform_source.dart
@@ -12,9 +12,7 @@ abstract interface class ConnectionPlatformSource {
   Future<bool> checkPrivilege();
 }
 
-class ConnectionPlatformSourceImpl
-    with InfraLogger
-    implements ConnectionPlatformSource {
+class ConnectionPlatformSourceImpl with InfraLogger implements ConnectionPlatformSource {
   @override
   Future<bool> checkPrivilege() async {
     try {
@@ -22,8 +20,7 @@ class ConnectionPlatformSourceImpl
         bool isElevated = false;
         withMemory<void, Uint32>(sizeOf<Uint32>(), (phToken) {
           withMemory<void, Uint32>(sizeOf<Uint32>(), (pReturnedSize) {
-            withMemory<void, _TokenElevation>(sizeOf<_TokenElevation>(),
-                (pElevation) {
+            withMemory<void, _TokenElevation>(sizeOf<_TokenElevation>(), (pElevation) {
               if (OpenProcessToken(
                     GetCurrentProcess(),
                     TOKEN_QUERY,
@@ -48,7 +45,17 @@ class ConnectionPlatformSourceImpl
           });
         });
         return isElevated;
-      } else if (Platform.isLinux || Platform.isMacOS) {
+      } else if (Platform.isLinux) {
+        final euid = geteuid();
+        return euid == 0;
+      } else if (Platform.isMacOS) {
+        final versionPart = Platform.operatingSystemVersion.split(".")[0].split(" ")[1];
+        final majorVersion = int.parse(versionPart);
+
+        if (majorVersion >= 13) {
+          return true;
+        }
+
         final euid = geteuid();
         return euid == 0;
       } else {

--- a/lib/singbox/service/macos13_singbox_service.dart
+++ b/lib/singbox/service/macos13_singbox_service.dart
@@ -1,0 +1,550 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'package:combine/combine.dart';
+import 'package:flutter/services.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:hiddify/core/model/directories.dart';
+import 'package:hiddify/singbox/model/singbox_config_option.dart';
+import 'package:hiddify/singbox/model/singbox_outbound.dart';
+import 'package:hiddify/singbox/model/singbox_stats.dart';
+import 'package:hiddify/singbox/model/singbox_status.dart';
+import 'package:hiddify/singbox/model/warp_account.dart';
+import 'package:hiddify/singbox/service/singbox_service.dart';
+import 'package:hiddify/utils/utils.dart';
+import 'package:loggy/loggy.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:watcher/watcher.dart';
+
+final _logger = Loggy('MacOS13SingboxService');
+
+class MethodChannelPort {
+  final String channelName;
+  final MethodChannel _methodChannel;
+
+  StreamController<dynamic>? _streamController;
+
+  MethodChannelPort(this.channelName) : _methodChannel = MethodChannel(channelName) {
+    _methodChannel.setMethodCallHandler(_handleMethodCall);
+  }
+
+  Future<dynamic> _handleMethodCall(MethodCall call) async {
+    switch (call.method) {
+      case 'sendMessage':
+        print("MethodChannelPort: ${call.arguments}");
+        _streamController?.add(call.arguments);
+        break;
+      default:
+        throw PlatformException(code: 'Unimplemented', details: 'Method not implemented in Dart: ${call.method}');
+    }
+  }
+
+  Stream<dynamic> asBroadcastStream({
+    void Function()? onListen,
+    void Function()? onCancel,
+  }) {
+    _streamController = StreamController<dynamic>.broadcast(
+      onListen: onListen,
+      onCancel: onCancel,
+    );
+
+    return _streamController!.stream;
+  }
+
+  void close() {
+    _methodChannel.setMethodCallHandler(null);
+    _streamController?.close();
+  }
+}
+
+class MacOS13SingboxService with InfraLogger implements SingboxService {
+  late final ValueStream<SingboxStatus> _status;
+  late final MethodChannelPort _statusReceiver;
+  Stream<SingboxStats>? _serviceStatsStream;
+  Stream<List<SingboxOutboundGroup>>? _outboundsStream;
+
+  static const platform = MethodChannel('app.hiddify.com.macos');
+
+  @override
+  Future<void> init() async {
+    loggy.debug("initializing");
+
+    // TODO: implement status receiver
+    _statusReceiver = MethodChannelPort('app.hiddify.com.macos/serviceStatus');
+    final source = _statusReceiver.asBroadcastStream().map((event) => jsonDecode(event as String)).map(SingboxStatus.fromEvent);
+    _status = ValueConnectableStream.seeded(
+      source,
+      const SingboxStopped(),
+    ).autoConnect();
+  }
+
+  @override
+  TaskEither<String, Unit> setup(
+    Directories directories,
+    bool debug,
+  ) {
+    return TaskEither(
+      () => CombineWorker().execute(
+        () async {
+          await platform.invokeMethod('setupOnce');
+
+          final Map<String, dynamic> args = {
+            'baseDir': directories.baseDir.path,
+            'workingDir': directories.workingDir.path,
+            'tempDir': directories.tempDir.path,
+            'debug': debug,
+          };
+
+          final String? error = await platform.invokeMethod<String>('setup', args);
+
+          if (error != null && error.isNotEmpty) {
+            return left(error);
+          }
+          return right(unit);
+        },
+      ),
+    );
+  }
+
+  @override
+  TaskEither<String, Unit> validateConfigByPath(
+    String path,
+    String tempPath,
+    bool debug,
+  ) {
+    return TaskEither(
+      () => CombineWorker().execute(
+        () async {
+          final Map<String, dynamic> args = {
+            'path': path,
+            'tempPath': tempPath,
+            'debug': debug,
+          };
+
+          final String? error = await platform.invokeMethod<String>('parse', args);
+
+          if (error != null && error.isNotEmpty) {
+            return left(error);
+          }
+          return right(unit);
+        },
+      ),
+    );
+  }
+
+  @override
+  TaskEither<String, Unit> changeOptions(SingboxConfigOption options) {
+    return TaskEither(
+      () => CombineWorker().execute(
+        () async {
+          final json = jsonEncode(options.toJson());
+          final Map<String, dynamic> args = {
+            'options': json,
+          };
+
+          final String? error = await platform.invokeMethod<String>('changeHiddifyOptions', args);
+
+          if (error != null && error.isNotEmpty) {
+            return left(error);
+          }
+          return right(unit);
+        },
+      ),
+    );
+  }
+
+  @override
+  TaskEither<String, String> generateFullConfigByPath(
+    String path,
+  ) {
+    return TaskEither(
+      () => CombineWorker().execute(
+        () async {
+          final Map<String, dynamic> args = {
+            'path': path,
+          };
+
+          final String? response = await platform.invokeMethod<String>('generateConfig', args);
+
+          if (response == null || response.isEmpty) {
+            return left("null response");
+          }
+          if (response.startsWith("error")) {
+            return left(response.replaceFirst("error", ""));
+          }
+          return right(response);
+        },
+      ),
+    );
+  }
+
+  @override
+  TaskEither<String, Unit> start(
+    String configPath,
+    String name,
+    bool disableMemoryLimit,
+  ) {
+    loggy.debug("starting, memory limit: [${!disableMemoryLimit}]");
+    return TaskEither(
+      () => CombineWorker().execute(
+        () async {
+          final Map<String, dynamic> args = {
+            'path': configPath,
+            'disableMemoryLimit': disableMemoryLimit,
+          };
+
+          final String? error = await platform.invokeMethod<String>('start', args);
+
+          if (error != null && error.isNotEmpty) {
+            return left(error);
+          }
+          return right(unit);
+        },
+      ),
+    );
+  }
+
+  @override
+  TaskEither<String, Unit> stop() {
+    return TaskEither(
+      () => CombineWorker().execute(
+        () async {
+          final Map<String, dynamic> args = {};
+          final String? error = await platform.invokeMethod<String>(
+            'stop',
+            args,
+          );
+
+          if (error != null && error.isNotEmpty) {
+            return left(error);
+          }
+          return right(unit);
+        },
+      ),
+    );
+  }
+
+  @override
+  TaskEither<String, Unit> restart(
+    String configPath,
+    String name,
+    bool disableMemoryLimit,
+  ) {
+    loggy.debug("restarting, memory limit: [${!disableMemoryLimit}]");
+    return TaskEither(
+      () => CombineWorker().execute(
+        () async {
+          final Map<String, dynamic> args = {
+            'path': configPath,
+            'disableMemoryLimit': disableMemoryLimit,
+          };
+
+          final String? error = await platform.invokeMethod<String>(
+            'restart',
+            args,
+          );
+
+          if (error != null && error.isNotEmpty) {
+            return left(error);
+          }
+          return right(unit);
+        },
+      ),
+    );
+  }
+
+  @override
+  TaskEither<String, Unit> resetTunnel() {
+    throw UnimplementedError(
+      "reset tunnel function unavailable on platform",
+    );
+  }
+
+  @override
+  Stream<SingboxStatus> watchStatus() => _status;
+
+  @override
+  Stream<SingboxStats> watchStats() {
+    if (_serviceStatsStream != null) return _serviceStatsStream!;
+    final receiver = MethodChannelPort('app.hiddify.com.macos/stats');
+    final statusStream = receiver.asBroadcastStream(
+      onCancel: () async {
+        _logger.debug("stopping stats command client");
+
+        final Map<String, dynamic> args = {
+          'id': 1,
+        };
+        final String? error = await platform.invokeMethod<String>('stopCommandClient', args);
+
+        if (error != null && error.isNotEmpty) {
+          _logger.error("error stopping stats client");
+        }
+        receiver.close();
+        _serviceStatsStream = null;
+      },
+    ).map(
+      (event) {
+        if (event case String _) {
+          if (event.startsWith('error:')) {
+            loggy.error("[service stats client] error received: $event");
+            throw event.replaceFirst('error:', "");
+          }
+          return SingboxStats.fromJson(
+            jsonDecode(event) as Map<String, dynamic>,
+          );
+        }
+        loggy.error("[service status client] unexpected type, msg: $event");
+        throw "invalid type";
+      },
+    );
+
+    Future<void> startStream() async {
+      final Map<String, dynamic> args = {
+        'id': 1,
+        'port': 1,
+      };
+      final String? error = await platform.invokeMethod<String>('startCommandClient', args);
+
+      if (error != null && error.isNotEmpty) {
+        loggy.error("error starting status command: $error");
+        throw error;
+      }
+    }
+
+    unawaited(startStream());
+
+    return _serviceStatsStream = statusStream;
+  }
+
+  @override
+  Stream<List<SingboxOutboundGroup>> watchGroups() {
+    final logger = newLoggy("watchGroups");
+    if (_outboundsStream != null) return _outboundsStream!;
+    final receiver = MethodChannelPort('app.hiddify.com.macos/groups');
+    final outboundsStream = receiver.asBroadcastStream(
+      onCancel: () async {
+        logger.debug("stopping");
+        receiver.close();
+        _outboundsStream = null;
+
+        final Map<String, dynamic> args = {
+          'id': 5,
+        };
+        final String? error = await platform.invokeMethod<String>('stopCommandClient', args);
+        if (error != null && error.isNotEmpty) {
+          logger.error("error stopping group client: $error");
+          throw error;
+        }
+      },
+    ).map(
+      (event) {
+        if (event case String _) {
+          if (event.startsWith('error:')) {
+            logger.error("error received: $event");
+            throw event.replaceFirst('error:', "");
+          }
+
+          return (jsonDecode(event) as List).map((e) {
+            return SingboxOutboundGroup.fromJson(e as Map<String, dynamic>);
+          }).toList();
+        }
+        logger.error("unexpected type, msg: $event");
+        throw "invalid type";
+      },
+    );
+
+    Future<void> startStream() async {
+      try {
+        final Map<String, dynamic> args = {
+          'id': 5,
+          'port': 2,
+        };
+
+        final String? error = await platform.invokeMethod<String>('startCommandClient', args);
+
+        if (error != null && error.isNotEmpty) {
+          logger.error("error starting group command: $error");
+          throw error;
+        }
+      } catch (e) {
+        receiver.close();
+        rethrow;
+      }
+    }
+
+    unawaited(startStream());
+
+    return _outboundsStream = outboundsStream;
+  }
+
+  @override
+  Stream<List<SingboxOutboundGroup>> watchActiveGroups() {
+    final logger = newLoggy("[ActiveGroupsClient]");
+    final receiver = MethodChannelPort('app.hiddify.com.macos/activeGroups');
+    final outboundsStream = receiver.asBroadcastStream(
+      onCancel: () async {
+        logger.debug("stopping");
+        receiver.close();
+
+        final Map<String, dynamic> args = {'id': 13};
+        final String? error = await platform.invokeMethod<String>('stopCommandClient', args);
+
+        if (error != null && error.isNotEmpty) {
+          logger.error("failed stopping: $error");
+        }
+      },
+    ).map(
+      (event) {
+        if (event case String _) {
+          if (event.startsWith('error:')) {
+            logger.error(event);
+            throw event.replaceFirst('error:', "");
+          }
+
+          return (jsonDecode(event) as List).map((e) {
+            return SingboxOutboundGroup.fromJson(e as Map<String, dynamic>);
+          }).toList();
+        }
+        logger.error("unexpected type, msg: $event");
+        throw "invalid type";
+      },
+    );
+
+    Future<void> startStream() async {
+      try {
+        final Map<String, dynamic> args = {
+          'id': 13,
+          'port': 3,
+        };
+
+        final String? error = await platform.invokeMethod<String>('startCommandClient', args);
+
+        if (error != null && error.isNotEmpty) {
+          logger.error("error starting: $error");
+          throw error;
+        }
+      } catch (e) {
+        receiver.close();
+        rethrow;
+      }
+    }
+
+    unawaited(startStream());
+
+    return outboundsStream;
+  }
+
+  @override
+  TaskEither<String, Unit> selectOutbound(String groupTag, String outboundTag) {
+    return TaskEither(
+      () => CombineWorker().execute(
+        () async {
+          final Map<String, dynamic> args = {
+            'groupTag': groupTag,
+            'outboundTag': outboundTag,
+          };
+
+          final String? error = await platform.invokeMethod<String>('selectOutbound', args);
+
+          if (error != null && error.isNotEmpty) {
+            return left(error);
+          }
+          return right(unit);
+        },
+      ),
+    );
+  }
+
+  @override
+  TaskEither<String, Unit> urlTest(String groupTag) {
+    return TaskEither(
+      () => CombineWorker().execute(
+        () async {
+          final Map<String, dynamic> args = {
+            'groupTag': groupTag,
+          };
+
+          final String? error = await platform.invokeMethod<String>('urlTest', args);
+
+          if (error != null && error.isNotEmpty) {
+            return left(error);
+          }
+          return right(unit);
+        },
+      ),
+    );
+  }
+
+  final _logBuffer = <String>[];
+  int _logFilePosition = 0;
+
+  @override
+  Stream<List<String>> watchLogs(String path) async* {
+    yield await _readLogFile(File(path));
+    yield* Watcher(path, pollingDelay: const Duration(seconds: 1)).events.asyncMap((event) async {
+      if (event.type == ChangeType.MODIFY) {
+        await _readLogFile(File(path));
+      }
+      return _logBuffer;
+    });
+  }
+
+  @override
+  TaskEither<String, Unit> clearLogs() {
+    return TaskEither(
+      () => CombineWorker().execute(
+        () {
+          _logBuffer.clear();
+          return right(unit);
+        },
+      ),
+    );
+  }
+
+  Future<List<String>> _readLogFile(File file) async {
+    if (_logFilePosition == 0 && file.lengthSync() == 0) return [];
+    final content = await file.openRead(_logFilePosition).transform(utf8.decoder).join();
+    _logFilePosition = file.lengthSync();
+    final lines = const LineSplitter().convert(content);
+    if (lines.length > 300) {
+      lines.removeRange(0, lines.length - 300);
+    }
+    for (final line in lines) {
+      _logBuffer.add(line);
+      if (_logBuffer.length > 300) {
+        _logBuffer.removeAt(0);
+      }
+    }
+    return _logBuffer;
+  }
+
+  @override
+  TaskEither<String, WarpResponse> generateWarpConfig({
+    required String licenseKey,
+    required String previousAccountId,
+    required String previousAccessToken,
+  }) {
+    loggy.debug("generating warp config");
+    return TaskEither(
+      () => CombineWorker().execute(
+        () async {
+          final Map<String, dynamic> args = {
+            'licenseKey': licenseKey,
+            'previousAccountId': previousAccountId,
+            'previousAccessToken': previousAccessToken,
+          };
+          final String? response = await platform.invokeMethod<String>('generateWarpConfig', args);
+
+          if (response == null || response.isEmpty) {
+            return left("Failed to generate warp config");
+          }
+
+          if (response.startsWith("error:")) {
+            return left(response.replaceFirst('error:', ""));
+          }
+          return right(warpFromJson(jsonDecode(response)));
+        },
+      ),
+    );
+  }
+}

--- a/lib/singbox/service/singbox_service.dart
+++ b/lib/singbox/service/singbox_service.dart
@@ -8,13 +8,23 @@ import 'package:hiddify/singbox/model/singbox_stats.dart';
 import 'package:hiddify/singbox/model/singbox_status.dart';
 import 'package:hiddify/singbox/model/warp_account.dart';
 import 'package:hiddify/singbox/service/ffi_singbox_service.dart';
+import 'package:hiddify/singbox/service/macos13_singbox_service.dart';
 import 'package:hiddify/singbox/service/platform_singbox_service.dart';
 
 abstract interface class SingboxService {
   factory SingboxService() {
     if (Platform.isAndroid || Platform.isIOS) {
       return PlatformSingboxService();
-    } else if (Platform.isLinux || Platform.isWindows || Platform.isMacOS) {
+    } else if (Platform.isLinux || Platform.isWindows) {
+      return FFISingboxService();
+    } else if (Platform.isMacOS) {
+      final versionPart = Platform.operatingSystemVersion.split(".")[0].split(" ")[1];
+      final majorVersion = int.parse(versionPart);
+
+      if (majorVersion >= 13) {
+        return MacOS13SingboxService();
+      }
+
       return FFISingboxService();
     }
     throw Exception("unsupported platform");

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -21,26 +21,26 @@ PODS:
     - FlutterMacOS
   - screen_retriever (0.0.1):
     - FlutterMacOS
-  - Sentry/HybridSDK (8.25.0)
-  - sentry_flutter (7.20.2):
+  - Sentry/HybridSDK (8.44.0)
+  - sentry_flutter (8.13.0):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.25.0)
+    - Sentry/HybridSDK (= 8.44.0)
   - share_plus (0.0.1):
     - FlutterMacOS
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - "sqlite3 (3.46.0+1)":
-    - "sqlite3/common (= 3.46.0+1)"
-  - "sqlite3/common (3.46.0+1)"
-  - "sqlite3/dbstatvtab (3.46.0+1)":
+  - "sqlite3 (3.46.1+1)":
+    - "sqlite3/common (= 3.46.1+1)"
+  - "sqlite3/common (3.46.1+1)"
+  - "sqlite3/dbstatvtab (3.46.1+1)":
     - sqlite3/common
-  - "sqlite3/fts5 (3.46.0+1)":
+  - "sqlite3/fts5 (3.46.1+1)":
     - sqlite3/common
-  - "sqlite3/perf-threadsafe (3.46.0+1)":
+  - "sqlite3/perf-threadsafe (3.46.1+1)":
     - sqlite3/common
-  - "sqlite3/rtree (3.46.0+1)":
+  - "sqlite3/rtree (3.46.1+1)":
     - sqlite3/common
   - sqlite3_flutter_libs (0.0.1):
     - FlutterMacOS
@@ -131,11 +131,11 @@ SPEC CHECKSUMS:
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   protocol_handler_macos: d10a6c01d6373389ffd2278013ab4c47ed6d6daa
   screen_retriever: 59634572a57080243dd1bf715e55b6c54f241a38
-  Sentry: cd86fc55628f5b7c572cabe66cc8f95a9d2f165a
-  sentry_flutter: 0cf2507eb90ff7a6aa3304e900dd7f08edbbefdf
+  Sentry: 0f9bc9adfc0b960e7f3bb5ec67e9a3d8193f3bdb
+  sentry_flutter: c4c3e7feec83e061daf829f6f9359efefab00d87
   share_plus: 76dd39142738f7a68dd57b05093b5e8193f220f7
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sqlite3: 292c3e1bfe89f64e51ea7fc7dab9182a017c8630
+  sqlite3: 0bb0e6389d824e40296f531b858a2a0b71c0d2fb
   sqlite3_flutter_libs: 5ca46c1a04eddfbeeb5b16566164aa7ad1616e7b
   tray_manager: 9064e219c56d75c476e46b9a21182087930baf90
   url_launcher_macos: 5f437abeda8c85500ceb03f5c1938a8c5a705399

--- a/macos/PrivilegedHelper/DartBridge.swift
+++ b/macos/PrivilegedHelper/DartBridge.swift
@@ -1,0 +1,530 @@
+//
+//  DartBridge.swift
+//  Runner
+//
+//  Created by Aleksandr Strizhnev on 20.02.2025.
+//
+
+import Foundation
+
+struct DartApiEntry {
+    var name: UnsafePointer<CChar>?
+    var function: (@convention(c) () -> Void)?
+}
+
+struct DartApi {
+    var major: Int32
+    var minor: Int32
+    var functions: UnsafePointer<DartApiEntry>?
+}
+
+enum Dart_CObject_Type: Int {
+    case kNull = 0
+    case kBool
+    case kInt32
+    case kInt64
+    case kDouble
+    case kString
+    case kArray
+    case kTypedData
+    case kExternalTypedData
+    case kSendPort
+    case kCapability
+    case kNativePointer
+    case kUnsupported
+    case kUnmodifiableExternalTypedData
+    case kNumberOfTypes
+}
+
+struct Dart_CObject {
+    var type: Dart_CObject_Type
+    
+    enum Dart_CObjectUnion {
+        case string(UnsafePointer<CChar>?)
+        case int32(Int32)
+        case int64(Int64)
+        case double(Double)
+
+        var stringValue: String? {
+            if case .string(let stringPointer) = self {
+                return stringPointer.map { String(cString: $0) }
+            }
+            return nil
+        }
+    }
+    
+    var value: Dart_CObjectUnion
+    
+    init(type: Dart_CObject_Type, stringValue: UnsafePointer<CChar>?) {
+        self.type = type
+        self.value = .string(stringValue)
+    }
+    
+    func getString() -> String? {
+        guard type == .kString else { return nil }
+        return value.stringValue
+    }
+}
+
+func getString(from rawPointer: UnsafeRawPointer) -> String? {
+    let dartCObject = rawPointer.bindMemory(to: Dart_CObject.self, capacity: 1)
+    return dartCObject.pointee.getString()
+}
+
+var Dart_PortListener: ((Int64, UnsafeRawPointer?) -> Void)? = nil
+
+@_cdecl("Dart_PostCObject")
+func Dart_PostCObject(port_id: Int64, message: UnsafeRawPointer?) -> Bool {
+    Dart_PortListener?(port_id, message)
+
+    return true
+}
+
+@_cdecl("Dart_PostInteger")
+func Dart_PostInteger(port_id: Int64, message: Int64) -> Bool {
+    return false
+}
+
+@_cdecl("Dart_NewNativePort")
+func Dart_NewNativePort(name: UnsafePointer<CChar>?, handler: UnsafeRawPointer?, handle_concurrently: Bool) -> Int64 {
+    return 0
+}
+
+@_cdecl("Dart_CloseNativePort")
+func Dart_CloseNativePort(native_port_id: Int64) -> Bool {
+    return false
+}
+
+@_cdecl("Dart_IsError")
+func Dart_IsError(handle: UnsafeRawPointer?) -> Bool {
+    return false
+}
+
+@_cdecl("Dart_IsApiError")
+func Dart_IsApiError(handle: UnsafeRawPointer?) -> Bool {
+    return false
+}
+
+@_cdecl("Dart_IsUnhandledExceptionError")
+func Dart_IsUnhandledExceptionError(handle: UnsafeRawPointer?) -> Bool {
+    return false
+}
+
+@_cdecl("Dart_IsCompilationError")
+func Dart_IsCompilationError(handle: UnsafeRawPointer?) -> Bool {
+    return false
+}
+
+@_cdecl("Dart_IsFatalError")
+func Dart_IsFatalError(handle: UnsafeRawPointer?) -> Bool {
+    return false
+}
+
+@_cdecl("Dart_GetError")
+func Dart_GetError(handle: UnsafeRawPointer?) -> UnsafePointer<CChar>? {
+    return nil
+}
+
+@_cdecl("Dart_ErrorHasException")
+func Dart_ErrorHasException(handle: UnsafeRawPointer?) -> Bool {
+    return false
+}
+
+@_cdecl("Dart_ErrorGetException")
+func Dart_ErrorGetException(handle: UnsafeRawPointer?) -> UnsafeRawPointer? {
+    return nil
+}
+
+@_cdecl("Dart_ErrorGetStackTrace")
+func Dart_ErrorGetStackTrace(handle: UnsafeRawPointer?) -> UnsafeRawPointer? {
+    return nil
+}
+
+@_cdecl("Dart_NewApiError")
+func Dart_NewApiError(error: UnsafePointer<CChar>?) -> UnsafeRawPointer? {
+    return nil
+}
+
+@_cdecl("Dart_NewCompilationError")
+func Dart_NewCompilationError(error: UnsafePointer<CChar>?) -> UnsafeRawPointer? {
+    return nil
+}
+
+@_cdecl("Dart_NewUnhandledExceptionError")
+func Dart_NewUnhandledExceptionError(exception: UnsafeRawPointer?) -> UnsafeRawPointer? {
+    return nil
+}
+
+@_cdecl("Dart_PropagateError")
+func Dart_PropagateError(handle: UnsafeRawPointer?) {
+}
+
+@_cdecl("Dart_HandleFromPersistent")
+func Dart_HandleFromPersistent(object: UnsafeRawPointer?) -> UnsafeRawPointer? {
+    return nil
+}
+
+@_cdecl("Dart_HandleFromWeakPersistent")
+func Dart_HandleFromWeakPersistent(object: UnsafeRawPointer?) -> UnsafeRawPointer? {
+    return nil
+}
+
+@_cdecl("Dart_NewPersistentHandle")
+func Dart_NewPersistentHandle(object: UnsafeRawPointer?) -> UnsafeRawPointer? {
+    return nil
+}
+
+@_cdecl("Dart_SetPersistentHandle")
+func Dart_SetPersistentHandle(obj1: UnsafeRawPointer?, obj2: UnsafeRawPointer?) {
+}
+
+@_cdecl("Dart_DeletePersistentHandle")
+func Dart_DeletePersistentHandle(object: UnsafeRawPointer?) {
+}
+
+@_cdecl("Dart_NewWeakPersistentHandle")
+func Dart_NewWeakPersistentHandle(object: UnsafeRawPointer?, peer: UnsafeRawPointer?, external_allocation_size: Int, callback: UnsafeRawPointer?) -> UnsafeRawPointer? {
+    return nil
+}
+
+@_cdecl("Dart_DeleteWeakPersistentHandle")
+func Dart_DeleteWeakPersistentHandle(object: UnsafeRawPointer?) {
+}
+
+@_cdecl("Dart_NewFinalizableHandle")
+func Dart_NewFinalizableHandle(object: UnsafeRawPointer?, peer: UnsafeRawPointer?, external_allocation_size: Int, callback: UnsafeRawPointer?) -> UnsafeRawPointer? {
+    return nil
+}
+
+@_cdecl("Dart_DeleteFinalizableHandle")
+func Dart_DeleteFinalizableHandle(object: UnsafeRawPointer?, strong_ref_to_object: UnsafeRawPointer?) {
+}
+
+@_cdecl("Dart_CurrentIsolate")
+func Dart_CurrentIsolate() -> UnsafeRawPointer? {
+    return nil
+}
+
+@_cdecl("Dart_ExitIsolate")
+func Dart_ExitIsolate() {
+}
+
+@_cdecl("Dart_EnterIsolate")
+func Dart_EnterIsolate(isolate: UnsafeRawPointer?) {
+}
+
+@_cdecl("Dart_Post")
+func Dart_Post(port_id: Int64, object: UnsafeRawPointer?) -> Bool {
+    return false
+}
+
+@_cdecl("Dart_NewSendPort")
+func Dart_NewSendPort(port_id: Int64) -> UnsafeRawPointer? {
+    return nil
+}
+
+@_cdecl("Dart_SendPortGetId")
+func Dart_SendPortGetId(port: UnsafeRawPointer?, port_id: UnsafeMutablePointer<Int64>?) -> UnsafeRawPointer? {
+    return nil
+}
+
+@_cdecl("Dart_EnterScope")
+func Dart_EnterScope() {
+}
+
+@_cdecl("Dart_ExitScope")
+func Dart_ExitScope() {
+}
+
+@_cdecl("Dart_IsNull")
+func Dart_IsNull(handle: UnsafeRawPointer?) -> Bool {
+    return false
+}
+
+@_cdecl("Dart_UpdateExternalSize")
+func Dart_UpdateExternalSize(object: UnsafeRawPointer?, external_allocation_size: Int) {
+}
+
+@_cdecl("Dart_UpdateFinalizableExternalSize")
+func Dart_UpdateFinalizableExternalSize(object: UnsafeRawPointer?, strong_ref_to_object: UnsafeRawPointer?, external_allocation_size: Int) {
+}
+
+func persistentCString(_ string: String) -> UnsafePointer<CChar> {
+    guard let ptr = strdup(string) else {
+        fatalError("Failed to strdup \(string)")
+    }
+    return UnsafePointer(ptr)
+}
+
+let dartApiEntries: [DartApiEntry] = [
+    DartApiEntry(
+        name: persistentCString("Dart_PostCObject"),
+        function: unsafeBitCast(
+            Dart_PostCObject as @convention(c) (Int64, UnsafeRawPointer?) -> Bool,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_PostInteger"),
+        function: unsafeBitCast(
+            Dart_PostInteger as @convention(c) (Int64, Int64) -> Bool,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_NewNativePort"),
+        function: unsafeBitCast(
+            Dart_NewNativePort as @convention(c) (UnsafePointer<CChar>?, UnsafeRawPointer?, Bool) -> Int64,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_CloseNativePort"),
+        function: unsafeBitCast(
+            Dart_CloseNativePort as @convention(c) (Int64) -> Bool,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_IsError"),
+        function: unsafeBitCast(
+            Dart_IsError as @convention(c) (UnsafeRawPointer?) -> Bool,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_IsApiError"),
+        function: unsafeBitCast(
+            Dart_IsApiError as @convention(c) (UnsafeRawPointer?) -> Bool,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_IsUnhandledExceptionError"),
+        function: unsafeBitCast(
+            Dart_IsUnhandledExceptionError as @convention(c) (UnsafeRawPointer?) -> Bool,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_IsCompilationError"),
+        function: unsafeBitCast(
+            Dart_IsCompilationError as @convention(c) (UnsafeRawPointer?) -> Bool,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_IsFatalError"),
+        function: unsafeBitCast(
+            Dart_IsFatalError as @convention(c) (UnsafeRawPointer?) -> Bool,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_GetError"),
+        function: unsafeBitCast(
+            Dart_GetError as @convention(c) (UnsafeRawPointer?) -> UnsafePointer<CChar>?,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_ErrorHasException"),
+        function: unsafeBitCast(
+            Dart_ErrorHasException as @convention(c) (UnsafeRawPointer?) -> Bool,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_ErrorGetException"),
+        function: unsafeBitCast(
+            Dart_ErrorGetException as @convention(c) (UnsafeRawPointer?) -> UnsafeRawPointer?,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_ErrorGetStackTrace"),
+        function: unsafeBitCast(
+            Dart_ErrorGetStackTrace as @convention(c) (UnsafeRawPointer?) -> UnsafeRawPointer?,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_NewApiError"),
+        function: unsafeBitCast(
+            Dart_NewApiError as @convention(c) (UnsafePointer<CChar>?) -> UnsafeRawPointer?,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_NewCompilationError"),
+        function: unsafeBitCast(
+            Dart_NewCompilationError as @convention(c) (UnsafePointer<CChar>?) -> UnsafeRawPointer?,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_NewUnhandledExceptionError"),
+        function: unsafeBitCast(
+            Dart_NewUnhandledExceptionError as @convention(c) (UnsafeRawPointer?) -> UnsafeRawPointer?,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_PropagateError"),
+        function: unsafeBitCast(
+            Dart_PropagateError as @convention(c) (UnsafeRawPointer?) -> Void,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_HandleFromPersistent"),
+        function: unsafeBitCast(
+            Dart_HandleFromPersistent as @convention(c) (UnsafeRawPointer?) -> UnsafeRawPointer?,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_HandleFromWeakPersistent"),
+        function: unsafeBitCast(
+            Dart_HandleFromWeakPersistent as @convention(c) (UnsafeRawPointer?) -> UnsafeRawPointer?,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_NewPersistentHandle"),
+        function: unsafeBitCast(
+            Dart_NewPersistentHandle as @convention(c) (UnsafeRawPointer?) -> UnsafeRawPointer?,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_SetPersistentHandle"),
+        function: unsafeBitCast(
+            Dart_SetPersistentHandle as @convention(c) (UnsafeRawPointer?, UnsafeRawPointer?) -> Void,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_DeletePersistentHandle"),
+        function: unsafeBitCast(
+            Dart_DeletePersistentHandle as @convention(c) (UnsafeRawPointer?) -> Void,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_NewWeakPersistentHandle"),
+        function: unsafeBitCast(
+            Dart_NewWeakPersistentHandle as @convention(c) (UnsafeRawPointer?, UnsafeRawPointer?, Int, UnsafeRawPointer?) -> UnsafeRawPointer?,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_DeleteWeakPersistentHandle"),
+        function: unsafeBitCast(
+            Dart_DeleteWeakPersistentHandle as @convention(c) (UnsafeRawPointer?) -> Void,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_NewFinalizableHandle"),
+        function: unsafeBitCast(
+            Dart_NewFinalizableHandle as @convention(c) (UnsafeRawPointer?, UnsafeRawPointer?, Int, UnsafeRawPointer?) -> UnsafeRawPointer?,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_DeleteFinalizableHandle"),
+        function: unsafeBitCast(
+            Dart_DeleteFinalizableHandle as @convention(c) (UnsafeRawPointer?, UnsafeRawPointer?) -> Void,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_CurrentIsolate"),
+        function: unsafeBitCast(
+            Dart_CurrentIsolate as @convention(c) () -> UnsafeRawPointer?,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_ExitIsolate"),
+        function: Dart_ExitIsolate as @convention(c) () -> Void
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_EnterIsolate"),
+        function: unsafeBitCast(
+            Dart_EnterIsolate as @convention(c) (UnsafeRawPointer?) -> Void,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_Post"),
+        function: unsafeBitCast(
+            Dart_Post as @convention(c) (Int64, UnsafeRawPointer?) -> Bool,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_NewSendPort"),
+        function: unsafeBitCast(
+            Dart_NewSendPort as @convention(c) (Int64) -> UnsafeRawPointer?,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_SendPortGetId"),
+        function: unsafeBitCast(
+            Dart_SendPortGetId as @convention(c) (UnsafeRawPointer?, UnsafeMutablePointer<Int64>?) -> UnsafeRawPointer?,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_EnterScope"),
+        function: Dart_EnterScope as @convention(c) () -> Void
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_ExitScope"),
+        function: Dart_ExitScope as @convention(c) () -> Void
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_IsNull"),
+        function: unsafeBitCast(
+            Dart_IsNull as @convention(c) (UnsafeRawPointer?) -> Bool,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_UpdateExternalSize"),
+        function: unsafeBitCast(
+            Dart_UpdateExternalSize as @convention(c) (UnsafeRawPointer?, Int) -> Void,
+            to: (@convention(c) () -> Void).self
+        )
+    ),
+    DartApiEntry(
+        name: persistentCString("Dart_UpdateFinalizableExternalSize"),
+        function: unsafeBitCast(
+            Dart_UpdateFinalizableExternalSize as @convention(c) (UnsafeRawPointer?, UnsafeRawPointer?, Int) -> Void,
+            to: (@convention(c) () -> Void).self
+        )
+    )
+]
+
+let entryCount = dartApiEntries.count
+let pinnedApiEntries = UnsafeMutablePointer<DartApiEntry>.allocate(capacity: entryCount)
+
+var dartApi = DartApi(major: 2, minor: 3, functions: UnsafePointer(pinnedApiEntries))
+
+let pinnedDartApi = UnsafeMutablePointer<DartApi>.allocate(capacity: 1)
+
+let rawDartApiPointer: UnsafeRawPointer = UnsafeRawPointer(pinnedDartApi)
+
+func setDartPortListener(_ listener: @escaping (Int64, UnsafeRawPointer?) -> Void) {
+    Dart_PortListener = listener
+}
+
+func createDartApi() -> UnsafeRawPointer {
+    pinnedApiEntries.initialize(from: dartApiEntries, count: entryCount)
+    pinnedDartApi.initialize(to: dartApi)
+    
+    return rawDartApiPointer
+}

--- a/macos/PrivilegedHelper/Singbox.swift
+++ b/macos/PrivilegedHelper/Singbox.swift
@@ -1,0 +1,315 @@
+//
+//  Singbox.swift
+//  Runner
+//
+//  Created by Aleksandr Strizhnev on 18.02.2025.
+//
+
+import Foundation
+
+class Singbox: NSObject, SingboxProtocol {    
+    private var receiver: SingboxReceiverProtocol?
+    private var singboxNative = try? SingboxDylib()
+    
+    init(receiver: SingboxReceiverProtocol? = nil) {
+        self.receiver = receiver
+    }
+    
+    private func portListener(_ port: Int64, _ ptr: UnsafeRawPointer?) {
+        guard let ptr, let receiver = NativeReceiver(rawValue: port) else {
+            return
+        }
+        let message = getString(from: ptr)
+        
+        self.receiver?.processMessage(
+            receiver: receiver,
+            message: message
+        )
+    }
+    
+    func setupOnce(
+        completion: (String?) -> Void
+    ) {
+        guard let singboxNative else {
+            completion("error singbox.dylib not loaded")
+            return
+        }
+        
+        do {
+            singboxNative.setPortListener(listener: self.portListener)
+            completion(
+                try singboxNative.setupOnce()
+            )
+        } catch {
+            completion(
+                "error \(error.localizedDescription)"
+            )
+        }
+    }
+    
+    func setup(
+        baseDir: String,
+        workingDir: String,
+        tempDir: String,
+        debug: Bool,
+        completion: (String?) -> Void
+    ) {
+        guard let singboxNative else {
+            completion("error singbox.dylib not loaded")
+            return
+        }
+        
+        do {
+            completion(
+                try singboxNative.setup(
+                    baseDir: baseDir,
+                    workingDir: workingDir,
+                    tempDir: tempDir,
+                    port: UInt64(NativeReceiver.serviceStatus.rawValue),
+                    debug: debug
+                )
+            )
+        } catch {
+            completion(
+                "error \(error.localizedDescription)"
+            )
+        }
+    }
+    
+    func parse(
+        path: String,
+        tempPath: String,
+        debug: Bool,
+        completion: (String?) -> Void
+    ) {
+        guard let singboxNative else {
+            completion("error singbox.dylib not loaded")
+            return
+        }
+        
+        do {
+            completion(
+                try singboxNative.parse(path: path, tempPath: tempPath, debug: debug)
+            )
+        } catch {
+            completion(
+                "error \(error.localizedDescription)"
+            )
+        }
+    }
+    
+    func changeHiddifyOptions(
+        options: String,
+        completion: (String?) -> Void
+    ) {
+        guard let singboxNative else {
+            completion("error singbox.dylib not loaded")
+            return
+        }
+        
+        do {
+            completion(try singboxNative.changeHiddifyOptions(options))
+        } catch {
+            completion(
+                "error \(error.localizedDescription)"
+            )
+        }
+    }
+    
+    func generateConfig(
+        path: String,
+        completion: (String?) -> Void
+    ) {
+        guard let singboxNative else {
+            completion("error singbox.dylib not loaded")
+            return
+        }
+        
+        do {
+            completion(
+                try singboxNative.generateConfig(path: path)
+            )
+        } catch {
+            completion(
+                "error \(error.localizedDescription)"
+            )
+        }
+    }
+    
+    func start(
+        path: String,
+        disableMemoryLimit: Bool,
+        completion: (String?) -> Void
+    ) {
+        guard let singboxNative else {
+            completion("error singbox.dylib not loaded")
+            return
+        }
+        
+        do {
+            completion(
+                try singboxNative.start(path: path, disableMemoryLimit: disableMemoryLimit)
+            )
+        } catch {
+            completion(
+                "error \(error.localizedDescription)"
+            )
+        }
+    }
+    
+    func stop(
+        completion: (String?) -> Void
+    ) {
+        guard let singboxNative else {
+            completion("error singbox.dylib not loaded")
+            return
+        }
+        
+        do {
+            completion(
+                try singboxNative.stop()
+            )
+        } catch {
+            completion(
+                "error \(error.localizedDescription)"
+            )
+        }
+    }
+    
+    func restart(
+        path: String,
+        disableMemoryLimit: Bool,
+        completion: (String?) -> Void
+    ) {
+        guard let singboxNative else {
+            completion("error singbox.dylib not loaded")
+            return
+        }
+        
+        do {
+            completion(
+                try singboxNative.restart(path: path, disableMemoryLimit: disableMemoryLimit)
+            )
+        } catch {
+            completion(
+                "error \(error.localizedDescription)"
+            )
+        }
+    }
+    
+    func stopCommandClient(
+        id: Int32,
+        completion: (String?) -> Void
+    ) {
+        guard let singboxNative else {
+            completion("error singbox.dylib not loaded")
+            return
+        }
+        
+        do {
+            completion(
+                try singboxNative.stopCommandClient(id: id)
+            )
+        } catch {
+            completion(
+                "error \(error.localizedDescription)"
+            )
+        }
+    }
+    
+    func startCommandClient(
+        id: Int32,
+        receiver: NativeReceiver,
+        completion: (String?) -> Void
+    ) {
+        guard let singboxNative else {
+            completion("error singbox.dylib not loaded")
+            return
+        }
+        
+        do {
+            completion(
+                try singboxNative.startCommandClient(
+                    id: id,
+                    port: UInt64(receiver.rawValue)
+                )
+            )
+        } catch {
+            completion(
+                "error \(error.localizedDescription)"
+            )
+        }
+    }
+    
+    func selectOutbound(
+        groupTag: String,
+        outboundTag: String,
+        completion: (String?) -> Void
+    ) {
+        guard let singboxNative else {
+            completion("error singbox.dylib not loaded")
+            return
+        }
+        
+        do {
+            completion(
+                try singboxNative.selectOutbound(
+                    groupTag: groupTag,
+                    outboundTag: outboundTag
+                )
+            )
+        } catch {
+            completion(
+                "error \(error.localizedDescription)"
+            )
+        }
+    }
+    
+    func urlTest(
+        groupTag: String,
+        completion: (String?) -> Void
+    ) {
+        guard let singboxNative else {
+            completion("error singbox.dylib not loaded")
+            return
+        }
+        
+        do {
+            completion(
+                try singboxNative.urlTest(
+                    groupTag: groupTag
+                )
+            )
+        } catch {
+            completion(
+                "error \(error.localizedDescription)"
+            )
+        }
+    }
+    
+    func generateWarpConfig(
+        licenseKey: String,
+        previousAccountId: String,
+        previousAccessToken: String,
+        completion: (String?) -> Void
+    ) {
+        guard let singboxNative else {
+            completion("error singbox.dylib not loaded")
+            return
+        }
+        
+        do {
+            completion(
+                try singboxNative.generateWarpConfig(
+                    licenseKey: licenseKey,
+                    previousAccountId: previousAccountId,
+                    previousAccessToken: previousAccessToken
+                )
+            )
+        } catch {
+            completion(
+                "error \(error.localizedDescription)"
+            )
+        }
+    }
+}

--- a/macos/PrivilegedHelper/SingboxNative.swift
+++ b/macos/PrivilegedHelper/SingboxNative.swift
@@ -1,0 +1,219 @@
+//
+//  SingboxNative.swift
+//  Runner
+//
+//  Created by Aleksandr Strizhnev on 20.02.2025.
+//
+
+import Foundation
+
+typealias NativePort = UInt64
+
+class SingboxDylib {
+    private var lib: UnsafeMutableRawPointer?
+//    private var dartApi: UnsafeMutablePointer<DartApi>
+    
+    init() throws {
+        guard let dylib = dlopen("libcore.dylib", RTLD_NOW) else {
+            throw DylibError.loadError(String(cString: dlerror()))
+        }
+        lib = dylib
+        
+//        self.dartApi = createDartApi()
+    }
+    
+    deinit {
+        dlclose(lib)
+    }
+    
+    private func getFunction<T>(_ name: String) throws -> T {
+        guard let lib else {
+            throw DylibError.loadError("Dylib not loaded")
+        }
+        
+        guard let symbol = dlsym(lib, name) else {
+            throw DylibError.symbolNotFound(name)
+        }
+        
+        return unsafeBitCast(symbol, to: T.self)
+    }
+    
+    func setPortListener(listener: @escaping (Int64, UnsafeRawPointer?) -> Void) {
+        setDartPortListener(listener)
+    }
+    
+    func setupOnce() throws -> String {
+        do {
+            let setupOnce: @convention(c) (UnsafeRawPointer) -> Void = try getFunction("setupOnce")
+            
+            setupOnce(
+                UnsafeMutableRawPointer(
+                    mutating: createDartApi()
+                )
+            )
+            
+            return "initialized"
+        } catch {
+            return "\(error)"
+        }
+    }
+    
+    func setup(
+        baseDir: String,
+        workingDir: String,
+        tempDir: String,
+        port: NativePort,
+        debug: Bool
+    ) throws -> String {
+        let setup: @convention(c) (
+            UnsafePointer<CChar>,
+            UnsafePointer<CChar>,
+            UnsafePointer<CChar>,
+            NativePort,
+            Int32
+        ) -> UnsafePointer<CChar> = try getFunction("setup")
+        
+        let result = setup(
+            strdup(baseDir),
+            strdup(workingDir),
+            strdup(tempDir),
+            port,
+            debug ? 1 : 0
+        )
+        
+        return String(cString: result)
+    }
+    
+    func changeHiddifyOptions(_ json: String) throws -> String {
+        let change: @convention(c) (UnsafePointer<CChar>) -> UnsafePointer<CChar> = try getFunction("changeHiddifyOptions")
+        let result = change(strdup(json))
+        
+        return String(cString: result)
+    }
+    
+    func parse(path: String, tempPath: String, debug: Bool) throws -> String {
+        let parse: @convention(c) (
+            UnsafePointer<CChar>,
+            UnsafePointer<CChar>,
+            Int32
+        ) -> UnsafePointer<CChar> = try getFunction("parse")
+        
+        return String(
+            cString: parse(strdup(path), strdup(tempPath), debug ? 1 : 0)
+        )
+    }
+    
+    func generateConfig(path: String) throws -> String {
+        let generateConfig: @convention(c) (
+            UnsafePointer<CChar>
+        ) -> UnsafePointer<CChar> = try getFunction("generateConfig")
+        
+        return String(
+            cString: generateConfig(strdup(path))
+        )
+    }
+    
+    func start(path: String, disableMemoryLimit: Bool) throws -> String {
+        let start: @convention(c) (
+            UnsafePointer<CChar>,
+            Int32
+        ) -> UnsafePointer<CChar> = try getFunction("start")
+        
+        return String(
+            cString: start(strdup(path), disableMemoryLimit ? 1 : 0)
+        )
+    }
+    
+    func restart(path: String, disableMemoryLimit: Bool) throws -> String {
+        let restart: @convention(c) (
+            UnsafePointer<CChar>,
+            Int32
+        ) -> UnsafePointer<CChar> = try getFunction("restart")
+        
+        return String(
+            cString: restart(strdup(path), disableMemoryLimit ? 1 : 0)
+        )
+    }
+    
+    func stop() throws -> String {
+        let stop: @convention(c) () -> UnsafePointer<CChar> = try getFunction("stop")
+        let result = stop()
+        
+        return String(cString: result)
+    }
+    
+    func stopCommandClient(id: Int32) throws -> String {
+        let stopClient: @convention(c) (Int32) -> UnsafePointer<CChar> = try getFunction("stopCommandClient")
+        let result = stopClient(id)
+        
+        return String(cString: result)
+    }
+    
+    func startCommandClient(id: Int32, port: NativePort) throws -> String {
+        let startClient: @convention(c) (Int32, NativePort) -> UnsafePointer<CChar> = try getFunction("startCommandClient")
+        let result = startClient(id, port)
+        
+        return String(cString: result)
+    }
+    
+    func selectOutbound(
+        groupTag: String,
+        outboundTag: String
+    ) throws -> String {
+        let selectOutbound: @convention(c) (
+            UnsafePointer<CChar>,
+            UnsafePointer<CChar>
+        ) -> UnsafePointer<CChar> = try getFunction("selectOutbound")
+        
+        return String(
+            cString: selectOutbound(strdup(groupTag), strdup(outboundTag))
+        )
+    }
+    
+    func generateWarpConfig(
+        licenseKey: String,
+        previousAccountId: String,
+        previousAccessToken: String
+    ) throws -> String {
+        let generateWarpConfig: @convention(c) (
+            UnsafePointer<CChar>,
+            UnsafePointer<CChar>,
+            UnsafePointer<CChar>
+        ) -> UnsafePointer<CChar> = try getFunction("generateWarpConfig")
+        
+        return String(
+            cString: generateWarpConfig(
+                strdup(licenseKey),
+                strdup(previousAccountId),
+                strdup(previousAccessToken)
+            )
+        )
+    }
+    
+    func urlTest(groupTag: String) throws -> String {
+        let test: @convention(c) (UnsafePointer<CChar>) -> UnsafePointer<CChar> = try getFunction("urlTest")
+        let result = test(strdup(groupTag))
+        
+        return String(cString: result)
+    }
+}
+
+enum DylibError: Error {
+    case loadError(String)
+    case symbolNotFound(String)
+}
+
+extension DylibError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .loadError(let message):
+            return NSLocalizedString(
+                "Failed to load dynamic library: \(message)", comment: "Dylib loading error"
+            )
+        case .symbolNotFound(let symbol):
+            return NSLocalizedString(
+                "Symbol '\(symbol)' not found in the dynamic library.", comment: "Dylib symbol error"
+            )
+        }
+    }
+}

--- a/macos/PrivilegedHelper/SingboxProtocol.swift
+++ b/macos/PrivilegedHelper/SingboxProtocol.swift
@@ -1,0 +1,98 @@
+//
+//  SingboxProtocol.swift
+//  Runner
+//
+//  Created by Aleksandr Strizhnev on 18.02.2025.
+//
+
+import Foundation
+
+@objc enum NativeReceiver: (Int64) {
+    case serviceStatus = 0
+    case stats = 1
+    case groups = 2
+    case activeGroups = 3
+}
+
+@objc protocol SingboxReceiverProtocol {
+    @objc func processMessage(
+        receiver: NativeReceiver,
+        message: String?
+    )
+}
+
+@objc protocol SingboxProtocol {
+    @objc func setupOnce(
+        completion: @escaping (String?) -> Void
+    )
+    
+    @objc func setup(
+        baseDir: String,
+        workingDir: String,
+        tempDir: String,
+        debug: Bool,
+        completion: @escaping (String?) -> Void
+    )
+    
+    @objc func parse(
+        path: String,
+        tempPath: String,
+        debug: Bool,
+        completion: @escaping (String?) -> Void
+    )
+    
+    @objc func changeHiddifyOptions(
+        options: String,
+        completion: @escaping (String?) -> Void
+    )
+    
+    @objc func generateConfig(
+        path: String,
+        completion: @escaping (String?) -> Void
+    )
+    
+    @objc func start(
+        path: String,
+        disableMemoryLimit: Bool,
+        completion: @escaping (String?) -> Void
+    )
+    
+    @objc func stop(
+        completion: @escaping (String?) -> Void
+    )
+    
+    @objc func restart(
+        path: String,
+        disableMemoryLimit: Bool,
+        completion: @escaping (String?) -> Void
+    )
+    
+    @objc func stopCommandClient(
+        id: Int32,
+        completion: @escaping (String?) -> Void
+    )
+    
+    @objc func startCommandClient(
+        id: Int32,
+        receiver: NativeReceiver,
+        completion: @escaping (String?) -> Void
+    )
+    
+    @objc func selectOutbound(
+        groupTag: String,
+        outboundTag: String,
+        completion: @escaping (String?) -> Void
+    )
+    
+    @objc func urlTest(
+        groupTag: String,
+        completion: @escaping (String?) -> Void
+    )
+    
+    @objc func generateWarpConfig(
+        licenseKey: String,
+        previousAccountId: String,
+        previousAccessToken: String,
+        completion: @escaping (String?) -> Void
+    )
+}

--- a/macos/PrivilegedHelper/app.hiddify.com.daemon.plist
+++ b/macos/PrivilegedHelper/app.hiddify.com.daemon.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>app.hiddify.com.daemon</string>
+	<key>MachServices</key>
+	<dict>
+		<key>app.hiddify.com.daemon.xpc</key>
+		<true/>
+	</dict>
+	<key>BundleProgram</key>
+	<string>Contents/Resources/PrivilegedHelper</string>
+	<key>KeepAlive</key>
+	<true/>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>ProcessType</key>
+	<string>Interactive</string>
+	<key>StandardErrorPath</key>
+	<string>/var/log/hiddify-helper.log</string>
+	<key>StandardOutPath</key>
+	<string>/var/log/hiddify-helper.log</string>
+	<key>UserName</key>
+	<string>root</string>
+	<key>GroupName</key>
+	<string>wheel</string>
+</dict>
+</plist>

--- a/macos/PrivilegedHelper/main.swift
+++ b/macos/PrivilegedHelper/main.swift
@@ -1,0 +1,60 @@
+//
+//  main.swift
+//  PrivilegedHelper
+//
+//  Created by Aleksandr Strizhnev on 18.02.2025.
+//
+
+import XPC
+import OSLog
+import Foundation
+
+let logger = Logger(subsystem: "hiddify-helper", category: "SingBoxHelper")
+
+class ServiceDelegate: NSObject, NSXPCListenerDelegate {
+    func listener(
+        _ listener: NSXPCListener,
+        shouldAcceptNewConnection newConnection: NSXPCConnection
+    ) -> Bool {
+
+        logger.info("[\(Date())] New connection attempt")
+        
+        newConnection.exportedInterface = NSXPCInterface(with: SingboxProtocol.self)
+        
+        newConnection.remoteObjectInterface = NSXPCInterface(with: SingboxReceiverProtocol.self)
+        
+        let exportedObject = Singbox(receiver: newConnection.remoteObjectProxy as? SingboxReceiverProtocol)
+        newConnection.exportedObject = exportedObject
+        
+        newConnection.interruptionHandler = {
+            logger.error("[\(Date())] Connection interrupted")
+        }
+        
+        newConnection.invalidationHandler = {
+            logger.error("[\(Date())] Connection invalidated")
+        }
+        
+        newConnection.resume()
+        logger.info("[\(Date())] Connection accepted")
+        return true
+    }
+}
+
+func startService() {
+    let delegate = ServiceDelegate()
+    let listener = NSXPCListener(machServiceName: "app.hiddify.com.daemon.xpc")
+    
+    listener.delegate = delegate
+    
+    signal(SIGTERM) { _ in
+        logger.error("[\(Date())] Received SIGTERM, shutting down...")
+        exit(0)
+    }
+    
+    logger.info("[\(Date())] Service starting...")
+    listener.resume()
+    
+    RunLoop.main.run()
+}
+
+startService()

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 73;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -28,6 +28,7 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		98B6D66F2D64B265001D68DB /* PrivilegedHelper in Resources */ = {isa = PBXBuildFile; fileRef = 98DC8B022D64A96900057778 /* PrivilegedHelper */; };
 		C2CEC907B854CCA50E3CB29E /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7774D5331C4F7054E7047DF2 /* Pods_RunnerTests.framework */; };
 		FEE8413B259D2FDED8BE933A /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A1027315C9B3E3F83410A09 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
@@ -47,6 +48,13 @@
 			remoteGlobalIDString = 33CC111A2044C6BA0003C045;
 			remoteInfo = FLX;
 		};
+		98F136A12D668DD4005C6569 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 33CC10E52044A3C60003C045 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 98DC8B012D64A96900057778;
+			remoteInfo = PrivilegedHelper;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -61,6 +69,15 @@
 			name = "Bundle Framework";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		98DC8AFC2D64A7AA00057778 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = Contents/Library/LaunchDaemons;
+			dstSubfolderSpec = 1;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -71,7 +88,7 @@
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* Hiddify.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Hiddify.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* Hiddify.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Hiddify.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -89,9 +106,34 @@
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		7C0B4F177A93E89661E9B0CB /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		98DC8B022D64A96900057778 /* PrivilegedHelper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = PrivilegedHelper; sourceTree = BUILT_PRODUCTS_DIR; };
 		D96FD811DCD14FAF8EC1F071 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		DBFB795F5E72237D66B9D391 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		98F136A42D669573005C6569 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				SingboxProtocol.swift,
+			);
+			target = 33CC10EC2044A3C60003C045 /* Runner */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
+		98B6D66E2D64B252001D68DB /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet;
+			buildPhase = 98DC8AFC2D64A7AA00057778 /* CopyFiles */;
+			membershipExceptions = (
+				app.hiddify.com.daemon.plist,
+			);
+		};
+/* End PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		98DC8B032D64A96900057778 /* PrivilegedHelper */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (98F136A42D669573005C6569 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 98B6D66E2D64B252001D68DB /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = PrivilegedHelper; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		331C80D2294CF70F00263BE5 /* Frameworks */ = {
@@ -107,6 +149,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				FEE8413B259D2FDED8BE933A /* Pods_Runner.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		98DC8AFF2D64A96900057778 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -152,6 +201,7 @@
 				33FAB671232836740065AC1E /* Runner */,
 				33CEB47122A05771004F2AC0 /* Flutter */,
 				331C80D6294CF71000263BE5 /* RunnerTests */,
+				98DC8B032D64A96900057778 /* PrivilegedHelper */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
 				0B357514C188DFB6739B421A /* Pods */,
@@ -163,6 +213,7 @@
 			children = (
 				33CC10ED2044A3C60003C045 /* Hiddify.app */,
 				331C80D5294CF71000263BE5 /* RunnerTests.xctest */,
+				98DC8B022D64A96900057778 /* PrivilegedHelper */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -244,10 +295,12 @@
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
 				DDB714AFDEF721265C0C3AF7 /* [CP] Embed Pods Frameworks */,
+				98DC8AFC2D64A7AA00057778 /* CopyFiles */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				98F136A22D668DD4005C6569 /* PBXTargetDependency */,
 				33CC11202044C79F0003C045 /* PBXTargetDependency */,
 			);
 			name = Runner;
@@ -255,13 +308,34 @@
 			productReference = 33CC10ED2044A3C60003C045 /* Hiddify.app */;
 			productType = "com.apple.product-type.application";
 		};
+		98DC8B012D64A96900057778 /* PrivilegedHelper */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 98DC8B062D64A96900057778 /* Build configuration list for PBXNativeTarget "PrivilegedHelper" */;
+			buildPhases = (
+				98DC8AFE2D64A96900057778 /* Sources */,
+				98DC8AFF2D64A96900057778 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				98DC8B032D64A96900057778 /* PrivilegedHelper */,
+			);
+			name = PrivilegedHelper;
+			packageProductDependencies = (
+			);
+			productName = PrivilegedHelper;
+			productReference = 98DC8B022D64A96900057778 /* PrivilegedHelper */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		33CC10E52044A3C60003C045 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0920;
+				LastSwiftUpdateCheck = 1600;
 				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
@@ -283,10 +357,12 @@
 						CreatedOnToolsVersion = 9.2;
 						ProvisioningStyle = Manual;
 					};
+					98DC8B012D64A96900057778 = {
+						CreatedOnToolsVersion = 16.0;
+					};
 				};
 			};
 			buildConfigurationList = 33CC10E82044A3C60003C045 /* Build configuration list for PBXProject "Runner" */;
-			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -294,6 +370,7 @@
 				Base,
 			);
 			mainGroup = 33CC10E42044A3C60003C045;
+			preferredProjectObjectVersion = 50;
 			productRefGroup = 33CC10EE2044A3C60003C045 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -301,6 +378,7 @@
 				33CC10EC2044A3C60003C045 /* Runner */,
 				331C80D4294CF70F00263BE5 /* RunnerTests */,
 				33CC111A2044C6BA0003C045 /* Flutter Assemble */,
+				98DC8B012D64A96900057778 /* PrivilegedHelper */,
 			);
 		};
 /* End PBXProject section */
@@ -317,6 +395,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				98B6D66F2D64B265001D68DB /* PrivilegedHelper in Resources */,
 				33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */,
 				33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */,
 			);
@@ -445,6 +524,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		98DC8AFE2D64A96900057778 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -457,6 +543,11 @@
 			isa = PBXTargetDependency;
 			target = 33CC111A2044C6BA0003C045 /* Flutter Assemble */;
 			targetProxy = 33CC111F2044C79F0003C045 /* PBXContainerItemProxy */;
+		};
+		98F136A22D668DD4005C6569 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 98DC8B012D64A96900057778 /* PrivilegedHelper */;
+			targetProxy = 98F136A12D668DD4005C6569 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -574,7 +665,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = Runner/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "Hiddify";
+				INFOPLIST_KEY_CFBundleDisplayName = Hiddify;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -702,7 +793,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = Runner/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "Hiddify";
+				INFOPLIST_KEY_CFBundleDisplayName = Hiddify;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -724,7 +815,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = Runner/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "Hiddify";
+				INFOPLIST_KEY_CFBundleDisplayName = Hiddify;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -750,6 +841,83 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
+		};
+		98DC8B072D64A96900057778 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		98DC8B082D64A96900057778 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		98DC8B092D64A96900057778 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Profile;
 		};
 /* End XCBuildConfiguration section */
 
@@ -790,6 +958,16 @@
 				33CC111C2044C6BA0003C045 /* Debug */,
 				33CC111D2044C6BA0003C045 /* Release */,
 				338D0CEB231458BD00FA5F75 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		98DC8B062D64A96900057778 /* Build configuration list for PBXNativeTarget "PrivilegedHelper" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				98DC8B072D64A96900057778 /* Debug */,
+				98DC8B082D64A96900057778 /* Release */,
+				98DC8B092D64A96900057778 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import FlutterMacOS
+import ServiceManagement
 
 import UserNotifications
 @main
@@ -8,6 +9,7 @@ class AppDelegate: FlutterAppDelegate {
     // https://github.com/leanflutter/window_manager/issues/214
     return false
   }
+    
   override func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Request notification authorization
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge]) { granted, error in
@@ -15,9 +17,34 @@ class AppDelegate: FlutterAppDelegate {
                 print("Error requesting notification authorization: \(error)")
             }
         }
+      
+      if #available(macOS 13.0, *) {
+          let service = SMAppService.daemon(plistName: "app.hiddify.com.daemon.plist")
+          
+          let status = service.status
+          
+          if service.status == .notRegistered {
+              do {
+                  try service.register()
+              } catch {
+                  print(error)
+              }
+          }
+      }
     }
-
-
+    
+    override func applicationWillTerminate(_ notification: Notification) {
+        if #available(macOS 13.0, *) {
+            let service = SMAppService.daemon(plistName: "app.hiddify.com.daemon.plist")
+            
+            do {
+                try service.unregister()
+            } catch {
+                print(error)
+            }
+        }
+    }
+    
   // // window manager restore from dock: https://leanflutter.dev/blog/click-dock-icon-to-restore-after-closing-the-window
   // override func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
   //     if !flag {

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,22 +1,345 @@
 import Cocoa
 import FlutterMacOS
 import window_manager
+import XPC
 
-class MainFlutterWindow: NSWindow {
-  override func awakeFromNib() {
-    let flutterViewController = FlutterViewController()
-    let windowFrame = self.frame
-    self.contentViewController = flutterViewController
-    self.setFrame(windowFrame, display: true)
+extension NativeReceiver {
+    var channelName: String {
+        switch self {
+        case .activeGroups:
+            return "app.hiddify.com.macos/activeGroups"
+        case .groups:
+            return "app.hiddify.com.macos/groups"
+        case .serviceStatus:
+            return "app.hiddify.com.macos/serviceStatus"
+        case .stats:
+            return "app.hiddify.com.macos/stats"
+        }
+    }
+}
 
-    RegisterGeneratedPlugins(registry: flutterViewController)
+class MainFlutterWindow: NSWindow, SingboxReceiverProtocol {
+    private var flutterViewController: FlutterViewController!
+    private var singboxConnection: NSXPCConnection!
+    private var receiverChannels: [NativeReceiver: FlutterMethodChannel] = [:]
+    
+    override func awakeFromNib() {
+        flutterViewController = FlutterViewController()
+        let windowFrame = frame
+        contentViewController = flutterViewController
+        setFrame(windowFrame, display: true)
+        
+        RegisterGeneratedPlugins(registry: flutterViewController)
+        
+        super.awakeFromNib()
+        
+        if #available(macOS 13.0, *) {
+            setupChannel()
+        }
+    }
+    
+    @available(macOS 13.0, *)
+    func setupChannel() {
+        let singboxChannel = FlutterMethodChannel(
+            name: "app.hiddify.com.macos",
+            binaryMessenger: flutterViewController.engine.binaryMessenger
+        )
+        
+        singboxChannel.setMethodCallHandler(singboxHandler)
+    }
+    
+    @available(macOS 13.0, *)
+    private func getOrCreateReceiverChannel(for receiver: NativeReceiver) -> FlutterMethodChannel {
+        if let existingChannel = receiverChannels[receiver] {
+            return existingChannel
+        }
+        
+        let channel = FlutterMethodChannel(
+            name: receiver.channelName,
+            binaryMessenger: flutterViewController.engine.binaryMessenger
+        )
+        
+        return channel
+    }
+    
+    @available(macOS 13.0, *)
+    private func setupConnection() {
+        singboxConnection = NSXPCConnection(machServiceName: "app.hiddify.com.daemon.xpc")
+        singboxConnection?.remoteObjectInterface = NSXPCInterface(
+            with: SingboxProtocol.self
+        )
+        singboxConnection?.exportedInterface = NSXPCInterface(
+            with: SingboxReceiverProtocol.self
+        )
+        singboxConnection?.exportedObject = self
+        
+        singboxConnection?.resume()
+        
+        singboxConnection?.interruptionHandler = { [weak self] in
+            self?.setupConnection()
+        }
+        
+        singboxConnection?.invalidationHandler = { [weak self] in
+            self?.setupConnection()
+        }
+    }
+    
+    @available(macOS 13.0, *)
+    private func getSingboxService() -> SingboxProtocol? {
+        return singboxConnection?.remoteObjectProxy as? SingboxProtocol
+    }
 
-    super.awakeFromNib()
-  }
-
-  // window manager hidden at launch
-  override public func order(_ place: NSWindow.OrderingMode, relativeTo otherWin: Int) {
-    super.order(place, relativeTo: otherWin)
-    hiddenWindowAtLaunch()
-  }
+    func processMessage(receiver: NativeReceiver, message: String?) {
+        if #available(macOS 13.0, *) {
+            let channel = getOrCreateReceiverChannel(for: receiver)
+            if let message = message {
+                channel.invokeMethod("sendMessage", arguments: message)
+            }
+        }
+    }
+    
+    @available(macOS 13.0, *)
+    private func singboxHandler(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let xpcService = getSingboxService() else {
+            setupConnection()
+            return singboxHandler(call, result: result)
+        }
+        
+        switch call.method {
+        case "setupOnce":
+            return xpcService.setupOnce {
+                result($0)
+            }
+        case "setup":
+            guard let args = call.arguments as? [String: Any],
+                  let baseDir = args["baseDir"] as? String,
+                  let workingDir = args["workingDir"] as? String,
+                  let tempDir = args["tempDir"] as? String,
+                  let debug = args["debug"] as? Bool
+            else {
+                result(
+                    FlutterError(
+                        code: "INVALID_ARGUMENTS",
+                        message: "Invalid arguments for setup",
+                        details: nil
+                    )
+                )
+                return
+            }
+            return xpcService.setup(
+                baseDir: baseDir,
+                workingDir: workingDir,
+                tempDir: tempDir,
+                debug: debug
+            ) {
+                result($0)
+            }
+            
+        case "parse":
+            guard let args = call.arguments as? [String: Any],
+                  let path = args["path"] as? String,
+                  let tempPath = args["tempPath"] as? String,
+                  let debug = args["debug"] as? Bool
+            else {
+                result(
+                    FlutterError(
+                        code: "INVALID_ARGUMENTS",
+                        message: "Invalid arguments for parse",
+                        details: nil
+                    )
+                )
+                return
+            }
+            return xpcService.parse(
+                path: path,
+                tempPath: tempPath,
+                debug: debug
+            ) {
+                result($0)
+            }
+            
+        case "changeHiddifyOptions":
+            guard let args = call.arguments as? [String: Any],
+                  let options = args["options"] as? String
+            else {
+                result(
+                    FlutterError(
+                        code: "INVALID_ARGUMENTS",
+                        message: "Invalid arguments for changeHiddifyOptions",
+                        details: nil
+                    )
+                )
+                return
+            }
+            return xpcService.changeHiddifyOptions(options: options) {
+                result($0)
+            }
+            
+        case "generateConfig":
+            guard let args = call.arguments as? [String: Any],
+                  let path = args["path"] as? String
+            else {
+                result(
+                    FlutterError(
+                        code: "INVALID_ARGUMENTS",
+                        message: "Invalid arguments for generateConfig",
+                        details: nil
+                    )
+                )
+                return
+            }
+            return xpcService.generateConfig(path: path) {
+                result($0)
+            }
+            
+        case "start":
+            guard let args = call.arguments as? [String: Any],
+                  let path = args["path"] as? String,
+                  let disableMemoryLimit = args["disableMemoryLimit"] as? Bool
+            else {
+                result(
+                    FlutterError(
+                        code: "INVALID_ARGUMENTS",
+                        message: "Invalid arguments for start",
+                        details: nil
+                    )
+                )
+                return
+            }
+            return xpcService.start(
+                path: path,
+                disableMemoryLimit: disableMemoryLimit
+            ) {
+                result($0)
+            }
+            
+        case "stop":
+            return xpcService.stop() {
+                result($0)
+            }
+            
+        case "restart":
+            guard let args = call.arguments as? [String: Any],
+                  let path = args["path"] as? String,
+                  let disableMemoryLimit = args["disableMemoryLimit"] as? Bool
+            else {
+                result(
+                    FlutterError(
+                        code: "INVALID_ARGUMENTS",
+                        message: "Invalid arguments for restart",
+                        details: nil
+                    )
+                )
+                return
+            }
+            return xpcService.restart(
+                path: path,
+                disableMemoryLimit: disableMemoryLimit
+            ) {
+                result($0)
+            }
+            
+        case "stopCommandClient":
+            guard let args = call.arguments as? [String: Any],
+                  let id = args["id"] as? Int32
+            else {
+                result(FlutterError(code: "INVALID_ARGUMENTS", message: "Invalid arguments for stopCommandClient", details: nil))
+                return
+            }
+            return xpcService.stopCommandClient(id: id) {
+                result($0)
+            }
+            
+        case "startCommandClient":
+            guard let args = call.arguments as? [String: Any],
+                  let id = args["id"] as? Int32,
+                  let port = args["port"] as? Int64,
+                  let receiver = NativeReceiver(rawValue: port)
+            else {
+                result(
+                    FlutterError(
+                        code: "INVALID_ARGUMENTS",
+                        message: "Invalid arguments for startCommandClient",
+                        details: nil
+                    )
+                )
+                return
+            }
+            return xpcService.startCommandClient(id: id, receiver: receiver) {
+                result($0)
+            }
+            
+        case "selectOutbound":
+            guard let args = call.arguments as? [String: Any],
+                  let groupTag = args["groupTag"] as? String,
+                  let outboundTag = args["outboundTag"] as? String
+            else {
+                result(
+                    FlutterError(
+                        code: "INVALID_ARGUMENTS",
+                        message: "Invalid arguments for selectOutbound",
+                        details: nil
+                    )
+                )
+                return
+            }
+            return xpcService.selectOutbound(
+                groupTag: groupTag,
+                outboundTag: outboundTag
+            ) {
+                result($0)
+            }
+            
+        case "urlTest":
+            guard let args = call.arguments as? [String: Any],
+                  let groupTag = args["groupTag"] as? String
+            else {
+                result(
+                    FlutterError(
+                        code: "INVALID_ARGUMENTS",
+                        message: "Invalid arguments for urlTest",
+                        details: nil
+                    )
+                )
+                return
+            }
+            return xpcService.urlTest(
+                groupTag: groupTag
+            ) {
+                result($0)
+            }
+            
+        case "generateWarpConfig":
+            guard let args = call.arguments as? [String: Any],
+                  let licenseKey = args["licenseKey"] as? String,
+                  let previousAccountId = args["previousAccountId"] as? String,
+                  let previousAccessToken = args["previousAccessToken"] as? String
+            else {
+                result(
+                    FlutterError(
+                        code: "INVALID_ARGUMENTS",
+                        message: "Invalid arguments for generateWarpConfig",
+                        details: nil
+                    )
+                )
+                return
+            }
+            return xpcService.generateWarpConfig(
+                licenseKey: licenseKey,
+                previousAccountId: previousAccountId,
+                previousAccessToken: previousAccessToken
+            ) {
+                result($0)
+            }
+            
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+    
+    // window manager hidden at launch
+    override public func order(_ place: NSWindow.OrderingMode, relativeTo otherWin: Int) {
+        super.order(place, relativeTo: otherWin)
+        hiddenWindowAtLaunch()
+    }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1428,26 +1428,26 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: "57514bc72d441ffdc463f498d6886aa586a2494fa467a1eb9d649c28010d7ee3"
+      sha256: "41a3c8e61d5194f5e12adf469fc430d7fa76a373fde6b11280f7df05c24e19e2"
       url: "https://pub.dev"
     source: hosted
-    version: "7.20.2"
+    version: "8.13.0"
   sentry_dart_plugin:
     dependency: "direct main"
     description:
       name: sentry_dart_plugin
-      sha256: e81fa3e0ffabd04fdcfbfecd6468d4a342f02ab33edca09708c61bcd2be42b7d
+      sha256: fb893ff20f51954e2cefd6b280c27c75d689bc65fc740b5bf9b7627453d46b7f
       url: "https://pub.dev"
     source: hosted
-    version: "1.7.1"
+    version: "2.4.0"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: "9723d58470ca43a360681ddd26abb71ca7b815f706bc8d3747afd054cf639ded"
+      sha256: "86ba98250bfc55cf3a9908afa46a851a46706e8338413d062daa5705ce016d05"
       url: "https://pub.dev"
     source: hosted
-    version: "7.20.2"
+    version: "8.13.0"
   share_plus:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,8 +49,8 @@ dependencies:
   url_launcher: ^6.2.5
   vclibs: ^0.1.2
   launch_at_startup: ^0.2.2
-  sentry_flutter: ^7.16.1
-  sentry_dart_plugin: ^1.7.1
+  sentry_flutter: ^8.13.0
+  sentry_dart_plugin: ^2.4.0
   combine: ^0.5.7
   path: ^1.8.3
   loggy: ^2.0.3
@@ -88,8 +88,8 @@ dependencies:
   json_path: ^0.7.1
   # permission_handler: ^11.3.0 # is not compatible with windows
   #flutter_easy_permission: ^1.1.2
-  flutter_easy_permission: 
-     git: https://github.com/unger1984/flutter_easy_permission.git
+  flutter_easy_permission:
+    git: https://github.com/unger1984/flutter_easy_permission.git
   in_app_review: ^2.0.9
   # circle_flags: ^4.0.2
   circle_flags:


### PR DESCRIPTION
I’ve added the `SingboxHelper` daemon agent, which registers on launch with privileged mode, allowing the VPN service to run smoothly without any hacks. To implement this, I added another `SingboxService` implementation, which is enabled by default on macOS 13+ (and honestly, I didn’t bother with settings no one’s asked for). macOS 13+ is the minimum supported version for the `SMAppService` daemons API, and while there’s `SMBlessJob`, it’s deprecated—so who even cares about supporting outdated macOS versions? Just to be clear, the app still works on earlier macOS versions, I just didn’t feel like writing two different daemon registration flows for those ancient OS versions.

Communication with the daemon is handled by `NSXPCConnection`, which is type-safe, secure, and fast. The daemon loads the `dylib`, so now all functions in `libcore` run with `sudo` rights, and the VPN mode just works™.

There’s also another thing: since `libcore` expects a `DartDL_API`, and Swift didn’t have that out of the box, I went ahead and created one. It’s mostly a bunch of stubs, semi-auto-generated from C++ headers (don’t judge me, I’m too lazy to finish the script and upload it, but it would be super easy, I swear). The only function that’s implemented so far is `Dart_PostCObject`, which receives different statuses from libcore. 

What else, code is type-safe, with all the necessary assertions, checks, and guards. It’s not the most readable thing in the world, but who cares if it solves the problem? And if anyone cares to tidy it up, it should be pretty easy to reorganize.