### PR TITLE
fix: removed void terms of the license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,17 +1,3 @@
-# Hiddify Extended GNU General Public License v3
-
-The Hiddify project is licensed under GPL v3, with the following additional conditions in accordance with GPL v3 Section 7. Failure to comply with these terms may result in requests to app stores to remove or restrict access to your app.
-
-# Additional Conditions to GPL v3:
-1.	**Source Code Availability:** If you use any part of this code, you must publish your source code on GitHub as a fork of the Hiddify repository and keep it up-to-date with any published app releases. Your repository should be shown as a fork of  https://github.com/hiddify/hiddify-app .
-2.	**Automated Release:** All releases must be made using GitHub Actions.
-3.	**Attribution:** You must give appropriate credit to Hiddify and https://github.com/hiddify/hiddify-app, link to the original license, and document any changes you have made in Readme.
-4.	**No Malware:** Adding any malware to the app is strictly prohibited.
-5.	**Naming and Interface Restrictions:** You are not allowed to  publish the app on any app store (e.g., AppStore, Google Play, F-Droid, Microsoft) with a name or user interface that closely resembles Hiddify (e.g., names like Hiddify, Hidy*, Hiddy*, *Ify or similar UI are prohibited).
-6.	**NonCommercial Use Only:** You may not use this material for commercial purposes, including selling and advertising, without prior written consent.
-7.	**ShareAlike Requirement:** If you remix, transform, or build upon the material, you must distribute your contributions under this same license as an open-source fork of https://github.com/hiddify/hiddify-app .
-
- 
 GNU General Public License
 ==========================
 


### PR DESCRIPTION
As per your own license (Part 7, paragraph 5):

> All other non-permissive additional terms are considered “further restrictions” within the meaning of section 10. If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term.

And so, to not confuse people who have not read the license in full, I suggest removing the additional terms, which don't hold any legal power anyway. To be clear, this does not change the meaning of the license in any way, since the additional terms can be ignored (as specified by the license itself)

This weird license has already caused the removal of hiddify from [nixpkgs](https://github.com/NixOS/nixpkgs/pull/435187)

And if somebody is going the put malware in hiddify, the license isn't going to stop them