### PR TITLE
feat: add Remnawave HWID device identification support

### DIFF
--- a/lib/core/app_info/device_info_provider.dart
+++ b/lib/core/app_info/device_info_provider.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/foundation.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// Returns device model string for use in x-device-model header.
+/// Returns empty string on unsupported platforms or on error.
+final deviceModelProvider = FutureProvider<String>((ref) async {
+  if (kIsWeb) return '';
+  final info = DeviceInfoPlugin();
+  try {
+    if (Platform.isAndroid) {
+      final d = await info.androidInfo;
+      return d.model;
+    } else if (Platform.isIOS) {
+      final d = await info.iosInfo;
+      return d.utsname.machine;
+    } else if (Platform.isWindows) {
+      final d = await info.windowsInfo;
+      return d.productName;
+    } else if (Platform.isMacOS) {
+      final d = await info.macOsInfo;
+      return d.model;
+    }
+  } catch (_) {}
+  return '';
+});

--- a/lib/core/http_client/dio_http_client.dart
+++ b/lib/core/http_client/dio_http_client.dart
@@ -111,6 +111,7 @@ class DioHttpClient with InfraLogger {
     String? userAgent,
     ({String username, String password})? credentials,
     bool proxyOnly = false,
+    Map<String, String>? extraHeaders,
   }) async {
     final mode = proxyOnly
         ? "proxy"
@@ -122,11 +123,11 @@ class DioHttpClient with InfraLogger {
       url,
       path,
       cancelToken: cancelToken,
-      options: _options(url, userAgent: userAgent, credentials: credentials),
+      options: _options(url, userAgent: userAgent, credentials: credentials, extraHeaders: extraHeaders),
     );
   }
 
-  Options _options(String url, {String? userAgent, ({String username, String password})? credentials}) {
+  Options _options(String url, {String? userAgent, ({String username, String password})? credentials, Map<String, String>? extraHeaders}) {
     final uri = Uri.parse(url);
 
     String? userInfo;
@@ -145,6 +146,7 @@ class DioHttpClient with InfraLogger {
       headers: {
         if (userAgent != null) "User-Agent": userAgent,
         if (basicAuth != null) "authorization": basicAuth,
+        if (extraHeaders != null) ...extraHeaders,
         // "Accept": "application/json",
         // "Content-Type": "application/json",
       },

--- a/lib/core/model/app_info_entity.dart
+++ b/lib/core/model/app_info_entity.dart
@@ -19,6 +19,16 @@ class AppInfoEntity with _$AppInfoEntity {
 
   String get userAgent => "HiddifyNext/$version ($operatingSystem) like ClashMeta v2ray sing-box";
 
+  /// Normalized OS name for HTTP headers (e.g. x-device-os).
+  String get displayOs => switch (operatingSystem) {
+    'android' => 'Android',
+    'ios' => 'iOS',
+    'macos' => 'macOS',
+    'windows' => 'Windows',
+    'linux' => 'Linux',
+    _ => operatingSystem,
+  };
+
   String get presentVersion => environment == Environment.prod ? version : "$version ${environment.name}";
 
   /// formats app info for sharing

--- a/lib/core/preferences/general_preferences.dart
+++ b/lib/core/preferences/general_preferences.dart
@@ -10,7 +10,9 @@ import 'package:hiddify/core/utils/preferences_utils.dart';
 import 'package:hiddify/features/per_app_proxy/model/per_app_proxy_mode.dart';
 import 'package:hiddify/features/window/notifier/window_notifier.dart';
 import 'package:hiddify/utils/platform_utils.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:uuid/uuid.dart';
 
 part 'general_preferences.g.dart';
 
@@ -128,3 +130,15 @@ class DebugModeNotifier extends _$DebugModeNotifier {
     return _pref.write(value);
   }
 }
+
+/// Persistent hardware ID — генерируется один раз при первом запуске.
+/// Используется для идентификации устройства на стороне панели (Remnawave HWID).
+final hwidProvider = Provider<String>((ref) {
+  final prefs = ref.read(sharedPreferencesProvider).requireValue;
+  const key = 'device_hwid';
+  final stored = prefs.getString(key);
+  if (stored != null && stored.isNotEmpty) return stored;
+  final hwid = const Uuid().v4();
+  prefs.setString(key, hwid);
+  return hwid;
+});

--- a/lib/features/profile/data/profile_parser.dart
+++ b/lib/features/profile/data/profile_parser.dart
@@ -4,8 +4,11 @@ import 'dart:io';
 import 'package:dartx/dartx.dart';
 import 'package:dio/dio.dart';
 import 'package:fpdart/fpdart.dart';
+import 'package:hiddify/core/app_info/app_info_provider.dart';
+import 'package:hiddify/core/app_info/device_info_provider.dart';
 import 'package:hiddify/core/db/db.dart';
 import 'package:hiddify/core/http_client/dio_http_client.dart';
+import 'package:hiddify/core/preferences/general_preferences.dart';
 import 'package:hiddify/features/profile/data/profile_data_mapper.dart';
 import 'package:hiddify/features/profile/model/profile_entity.dart';
 import 'package:hiddify/features/profile/model/profile_failure.dart';
@@ -149,6 +152,16 @@ class ProfileParser {
     // if (url.startsWith("http://"))
     //   throw const ProfileFailure.invalidUrl('HTTP is not supported. Please use HTTPS for secure connection.');
 
+    final appInfo = _ref.read(appInfoProvider).requireValue;
+    final hwid = _ref.read(hwidProvider);
+    final deviceModel = await _ref.read(deviceModelProvider.future);
+    final hwidHeaders = <String, String>{
+      'x-hwid': hwid,
+      'x-device-os': appInfo.displayOs,
+      'x-ver-os': appInfo.operatingSystemVersion,
+      if (deviceModel.isNotEmpty) 'x-device-model': deviceModel,
+    };
+
     final rs = await _httpClient
         .download(
           url.trim(),
@@ -157,6 +170,7 @@ class ProfileParser {
           userAgent: _ref.read(ConfigOptions.useXrayCoreWhenPossible)
               ? _httpClient.userAgent.replaceAll("HiddifyNext", "HiddifyNextX")
               : null,
+          extraHeaders: hwidHeaders,
         )
         .catchError((err) {
           if (CancelToken.isCancel(err as DioException)) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   screen_retriever: ^0.2.0
 
   package_info_plus: ^8.1.0
+  device_info_plus: ^10.1.0
 
   url_launcher: ^6.2.5
   vclibs: ^0.1.2


### PR DESCRIPTION
Adds support for Remnawave panel HWID feature for device identification/limiting via subscription request headers.

Headers sent on every subscription fetch:
- `x-hwid` — persistent UUID (generated once, stored in SharedPreferences)
- `x-device-os` — normalized OS name (Android, iOS, Windows, macOS, Linux)
- `x-ver-os` — OS version string
- `x-device-model` — device model via device_info_plus

Changes:
- pubspec.yaml: add device_info_plus ^10.1.0
- lib/core/app_info/device_info_provider.dart: FutureProvider returning device model per platform
- lib/core/model/app_info_entity.dart: displayOs getter for normalized OS name
- lib/core/preferences/general_preferences.dart: hwidProvider (UUID v4, persisted)
- lib/core/http_client/dio_http_client.dart: extraHeaders param in download() and _options()
- lib/features/profile/data/profile_parser.dart: pass HWID headers on subscription download

Non-breaking: panels that don't use HWID simply ignore the headers.