### PR TITLE
Prevent blank-screen launch when the auto-start registry key is missing (Windows)

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -77,7 +77,7 @@ Future<void> lazyBootstrap(WidgetsBinding widgetsBinding, Environment env) async
     } else {
       Logger.bootstrap.debug("silent start, remain hidden accessible via tray");
     }
-    await _init("auto start service", () => container.read(autoStartNotifierProvider.future));
+    await _safeInit("auto start service", () => container.read(autoStartNotifierProvider.future));
   }
   await _init("logs repository", () => container.read(logRepositoryProvider.future));
   await _init("logger controller", () => LoggerController.postInit(debug));

--- a/lib/features/auto_start/notifier/auto_start_notifier.dart
+++ b/lib/features/auto_start/notifier/auto_start_notifier.dart
@@ -21,11 +21,26 @@ class AutoStartNotifier extends _$AutoStartNotifier with InfraLogger {
       appPath: Platform.resolvedExecutable,
       packageName: "Hiddify.HiddifyNext",
     );
-    final isEnabled = await launchAtStartup.isEnabled();
+    final isEnabled = await _isEnabledSafe();
     loggy.info("auto start is [${isEnabled ? "Enabled" : "Disabled"}]");
     _startTimer();
     ref.onDispose(() => _timer?.cancel());
     return isEnabled;
+  }
+
+  /// Reads the launch-at-startup status, treating a read failure as disabled.
+  ///
+  /// On a fresh Windows install the relevant registry key may not exist yet,
+  /// in which case `launchAtStartup.isEnabled()` throws instead of returning
+  /// false. A missing key means auto start is not registered, so treat any
+  /// read failure as disabled rather than letting it propagate.
+  Future<bool> _isEnabledSafe() async {
+    try {
+      return await launchAtStartup.isEnabled();
+    } catch (e, stackTrace) {
+      loggy.warning("failed to read auto start status, assuming disabled", e, stackTrace);
+      return false;
+    }
   }
 
   void _startTimer() {
@@ -35,7 +50,7 @@ class AutoStartNotifier extends _$AutoStartNotifier with InfraLogger {
 
   Future<bool> updateStatus() async {
     loggy.debug("update auto start status");
-    final isEnabled = await launchAtStartup.isEnabled();
+    final isEnabled = await _isEnabledSafe();
     state = AsyncValue.data(isEnabled);
     return isEnabled;
   }


### PR DESCRIPTION
### Problem

On Windows, `AutoStartNotifier.build()` awaits `launchAtStartup.isEnabled()`, which reads `HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run`. The `launch_at_startup` package opens that key without handling its absence, so on a fresh Windows install where no application has registered a startup entry yet and the key does not exist, it throws instead of returning `false`.

That throw propagates out of `build()`, and bootstrap initializes the auto start service through `_init`, which rethrows. The rethrow aborts `lazyBootstrap` before `runApp()` is reached, so the app shows a blank screen with no UI.

### Fix

- `auto_start_notifier.dart`: read the status through a new `_isEnabledSafe()` that treats any read failure as disabled. A missing key means auto start is not registered, so `false` is the correct status. The periodic `updateStatus()` refresh uses the same guard.
- `bootstrap.dart`: initialize the auto start service through `_safeInit` instead of `_init`, matching the system tray and other non-critical desktop services, so its failure cannot prevent launch.
