### PR TITLE
Prevent blank-screen launch when core init fails during bootstrap

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -97,7 +97,7 @@ Future<void> lazyBootstrap(WidgetsBinding widgetsBinding, Environment env) async
     "chain profile unblocker",
     () => container.read(chainProfileNotifierProvider(ChainType.unblocker).future),
   );
-  await _init("hiddify-core", () => container.read(hiddifyCoreServiceProvider).init());
+  await _safeInit("hiddify-core", () => container.read(hiddifyCoreServiceProvider).init());
 
   // Eagerly listen to activeProxyNotifierProvider to force synchronous evaluation in microtasks,
   // avoiding lazy build-phase flushes and sibling dependency collisions on the Home page.

--- a/lib/core/notification/in_app_notification_controller.dart
+++ b/lib/core/notification/in_app_notification_controller.dart
@@ -14,25 +14,33 @@ InAppNotificationController inAppNotificationController(Ref ref) {
 enum NotificationType { info, error, success }
 
 class InAppNotificationController with AppLogger {
-  ToastificationItem _show(
+  ToastificationItem? _show(
     String message, {
     NotificationType type = NotificationType.info,
     Duration duration = const Duration(seconds: 3),
   }) {
-    toastification.dismissAll();
-    return toastification.show(
-      title: Text(message),
-      type: type._toastificationType,
-      alignment: AlignmentDirectional.bottomCenter,
-      margin: const EdgeInsets.only(bottom: 64 + 16, right: 16, left: 16),
-      autoCloseDuration: duration,
-      style: ToastificationStyle.fillColored,
-      pauseOnHover: true,
-      showProgressBar: false,
-      dragToClose: true,
-      closeOnClick: true,
-      closeButtonShowType: CloseButtonShowType.onHover,
-    );
+    // Notifications raised during bootstrap (before runApp) have no overlay to
+    // attach to, and toastification throws when it cannot find one. Swallow
+    // that so a notification can never abort startup or crash the app.
+    try {
+      toastification.dismissAll();
+      return toastification.show(
+        title: Text(message),
+        type: type._toastificationType,
+        alignment: AlignmentDirectional.bottomCenter,
+        margin: const EdgeInsets.only(bottom: 64 + 16, right: 16, left: 16),
+        autoCloseDuration: duration,
+        style: ToastificationStyle.fillColored,
+        pauseOnHover: true,
+        showProgressBar: false,
+        dragToClose: true,
+        closeOnClick: true,
+        closeButtonShowType: CloseButtonShowType.onHover,
+      );
+    } catch (e, stackTrace) {
+      loggy.warning("failed to show notification, overlay may not be ready", e, stackTrace);
+      return null;
+    }
   }
 
   ToastificationItem? showErrorToast(String message) =>


### PR DESCRIPTION
### Problem

When `hiddify-core` setup fails during bootstrap (for example when its port is already in use), the failure handler in `HiddifyCoreService.init` calls `showErrorToast`. That runs before `runApp()`, when no Toastification overlay exists yet, so `findToastificationOverlayState` does a null check on a null value and throws. The exception propagates out of `_init("hiddify-core", ...)` and aborts `lazyBootstrap` before `runApp()` is reached, leaving a blank screen.

This matches the log in #2159.

### Fix

- `in_app_notification_controller.dart`: wrap the private `_show` in a try/catch that logs and returns null when the overlay is unavailable, so a notification can never abort startup or crash the app. `_show` becomes nullable to match; the public `showErrorToast` / `showSuccessToast` / `showInfoToast` were already nullable, so no callers change.
- `bootstrap.dart`: initialize `hiddify-core` through `_safeInit` so a setup failure is logged and the app still launches, matching how the active profile and system tray are already initialized.

### Notes

- The try/catch in `_show` is intentionally catch-all: a notification failing for any reason should never crash the app, and it is logged with a stack trace.
- After a failed core setup the error is now written to the log rather than shown (the overlay does not exist that early in bootstrap). Surfacing it in the UI once the app is up could be a follow-up.
