### PR TITLE
fix(profile): show subscription-userinfo total=0 as unlimited (#1974)

### DIFF
--- a/lib/features/profile/data/profile_parser.dart
+++ b/lib/features/profile/data/profile_parser.dart
@@ -28,7 +28,12 @@ import 'package:meta/meta.dart';
 /// - local: fallback to protocol, extracted from content by protocol()
 
 class ProfileParser {
-  static const infiniteTrafficThreshold = 920_233_720_368;
+  // Synthetic sentinel assigned to `total` for "unlimited" traffic (subscription-userinfo total=0 or
+  // missing). It MUST stay above the 10 TB "unlimited" threshold the UI uses to decide whether to show
+  // "∞" (isInfinitSize() in lib/utils/number_formatters.dart, and profile_tile.dart). The previous
+  // value (~857 GiB) was below that gate, so total=0 rendered as a finite cap / "quota exceeded".
+  // See https://github.com/hiddify/hiddify-app/issues/1974 . 1000 TiB.
+  static const infiniteTrafficThreshold = 1_099_511_627_776_000;
   static const infiniteTimeThreshold = 92_233_720_368;
   static const allowedOverrideConfigs = [
     'connection-test-url',


### PR DESCRIPTION
## Problem

Fixes #1974.

`subscription-userinfo: ...; total=0` (or a missing `total`) is supposed to mean **unlimited** traffic, but the app instead shows a finite cap (~85.9 GiB / ~857 GiB depending on build) with a full progress bar / "quota exceeded", even though traffic still works.

## Root cause

The parser turns `total=0` into a synthetic "unlimited" sentinel — `lib/features/profile/data/profile_parser.dart`:

```dart
static const infiniteTrafficThreshold = 920_233_720_368; // ≈ 857 GiB
...
final total1 = (total == null || total == 0) ? infiniteTrafficThreshold + 1 : total;
```

…but the UI decides "unlimited" with a completely **different, unrelated 10 TB threshold**:

- `lib/utils/number_formatters.dart`: `bool isInfinitSize() => bytes().terabytes.toDouble() > 10;` (used by `profile_tile_main.dart`)
- `lib/features/profile/widget/profile_tile.dart`: `... total > 10 * 1099511627776 /*10TB*/ ? "∞ GiB" : ...`

`857 GiB < 10 TB`, so the sentinel never trips `isInfinitSize()` and is rendered as a finite value; `ratio = consumption / total` (`profile_entity.dart`) then fills the bar → the "quota exceeded" look. The parser says *"this is infinite"*, the widgets say *"this is just 857 GiB"* — the two constants were never reconciled.

Notes:
- The **85.9 GiB** several reporters see is the sibling constant `infiniteTimeThreshold = 92_233_720_368` (= `int64Max ~/ 1e8`); some builds reuse it for traffic. Either way both sentinels sit below the 10 TB display gate, so the magnitude varies by build but the bug is identical.
- The desktop-vs-mobile inconsistency reported on the issue is the same cause: `profile_tile.dart` and `profile_tile_main.dart` both apply the 10 TB gate, they just render the sub-threshold sentinel differently.

## Fix

Raise the traffic "unlimited" sentinel above the UI's 10 TB gate, so `isInfinitSize()` / `profile_tile.dart` recognise it as unlimited:

```diff
- static const infiniteTrafficThreshold = 920_233_720_368;       // ≈857 GiB, below the 10 TB UI gate
+ static const infiniteTrafficThreshold = 1_099_511_627_776_000; // 1000 TiB, above the 10 TB UI gate
```

One line. The existing test (`"Should use infinite when given 0 for subscription properties"`), which asserts `subInfo.total == ProfileParser.infiniteTrafficThreshold + 1`, references the constant and stays green.

A cleaner long-term fix would be a single `SubscriptionInfo.isUnlimited` used by both the parser sentinel and the widgets, instead of two unrelated thresholds — happy to send that version instead if you prefer.
