### PR TITLE
fix(profile): accept subscription-userinfo with only upload+download (#2242)

### DIFF
--- a/lib/features/profile/data/profile_parser.dart
+++ b/lib/features/profile/data/profile_parser.dart
@@ -289,7 +289,13 @@ class ProfileParser {
   static SubscriptionInfo? _parseSubscriptionInfo(String subInfoStr) {
     final values = subInfoStr.split(';');
     final map = {for (final v in values) v.split('=').first.trim(): num.tryParse(v.split('=').second.trim())?.toInt()};
-    if (map case {"upload": final upload?, "download": final download?, "total": final total, "expire": var expire}) {
+    // Only upload+download are required. total/expire are optional - many panels omit them (e.g.
+    // `expire` for no-expiry plans) - and are already defaulted to the "unlimited" sentinels below.
+    // Requiring their keys here discarded the WHOLE subscription-userinfo when either was absent,
+    // which silently drops the usage bar AND the support-url / profile-web-page-url tiles.
+    if (map case {"upload": final upload?, "download": final download?}) {
+      final total = map["total"];
+      var expire = map["expire"];
       final total1 = (total == null || total == 0) ? infiniteTrafficThreshold + 1 : total;
       expire = (expire == null || expire == 0) ? infiniteTimeThreshold : expire;
       return SubscriptionInfo(

--- a/lib/features/profile/data/profile_parser.dart
+++ b/lib/features/profile/data/profile_parser.dart
@@ -287,25 +287,39 @@ class ProfileParser {
   }
 
   static SubscriptionInfo? _parseSubscriptionInfo(String subInfoStr) {
-    final values = subInfoStr.split(';');
-    final map = {for (final v in values) v.split('=').first.trim(): num.tryParse(v.split('=').second.trim())?.toInt()};
-    // Only upload+download are required. total/expire are optional - many panels omit them (e.g.
-    // `expire` for no-expiry plans) - and are already defaulted to the "unlimited" sentinels below.
-    // Requiring their keys here discarded the WHOLE subscription-userinfo when either was absent,
-    // which silently drops the usage bar AND the support-url / profile-web-page-url tiles.
-    if (map case {"upload": final upload?, "download": final download?}) {
-      final total = map["total"];
-      var expire = map["expire"];
-      final total1 = (total == null || total == 0) ? infiniteTrafficThreshold + 1 : total;
-      expire = (expire == null || expire == 0) ? infiniteTimeThreshold : expire;
-      return SubscriptionInfo(
-        upload: upload,
-        download: download,
-        total: total1,
-        expire: DateTime.fromMillisecondsSinceEpoch(expire * 1000),
-      );
+    // Parse "key=value;key=value" defensively: skip any segment that isn't a well-formed key=value
+    // pair instead of throwing. A malformed segment (no '=') would otherwise bubble up through
+    // parse()'s tryCatch and drop the WHOLE profile.
+    final map = <String, int?>{};
+    for (final segment in subInfoStr.split(';')) {
+      final parts = segment.split('=');
+      if (parts.length < 2) continue;
+      // Guard toInt() against non-finite values: num.tryParse of "1e999"/"Infinity"/"NaN" yields a
+      // non-finite double and double.toInt() throws on those, which would again take down the whole
+      // profile parse. Treat them as absent so the field falls back gracefully (null / unlimited sentinel).
+      final value = num.tryParse(parts[1].trim());
+      map[parts.first.trim()] = (value != null && value.isFinite) ? value.toInt() : null;
     }
-    return null;
+
+    // Only upload+download are required. total/expire are optional - panels omit total for unlimited
+    // plans and expire for no-expiry plans - and default to the "unlimited" sentinels below. Requiring
+    // their keys discarded the WHOLE subscription-userinfo when either was absent, silently dropping the
+    // usage bar AND the support-url / profile-web-page-url tiles parsed alongside it.
+    final upload = map['upload'];
+    final download = map['download'];
+    if (upload == null || download == null) return null;
+
+    final total = map['total'];
+    final expire = map['expire'];
+    final resolvedTotal = (total == null || total == 0) ? infiniteTrafficThreshold + 1 : total;
+    final resolvedExpire = (expire == null || expire == 0) ? infiniteTimeThreshold : expire;
+
+    return SubscriptionInfo(
+      upload: upload,
+      download: download,
+      total: resolvedTotal,
+      expire: DateTime.fromMillisecondsSinceEpoch(resolvedExpire * 1000),
+    );
   }
 
   @visibleForTesting

--- a/test/features/profile/data/profile_parser_test.dart
+++ b/test/features/profile/data/profile_parser_test.dart
@@ -162,5 +162,222 @@ void main() {
         });
       });
     });
+
+    test("Should keep subscription info when total and expire are omitted", () {
+      // Panels routinely omit total (unlimited plans) and expire (no-expiry plans). The header must
+      // still produce a SubscriptionInfo, and the support-url / profile-web-page-url tiles parsed
+      // alongside it must still be applied. Regression test for #2242.
+      final headers = <String, List<String>>{
+        "profile-title": ["title"],
+        "subscription-userinfo": ["upload=100;download=200"],
+        "profile-web-page-url": [validBaseUrl],
+        "support-url": [validSupportUrl],
+      };
+      final fixedHeaders = headers.map((key, value) {
+        if (value.length == 1) return MapEntry(key, value.first);
+        return MapEntry(key, value);
+      });
+      final allHeaders = ProfileParser.populateHeaders(content: '', remoteHeaders: fixedHeaders);
+      expect(allHeaders.isRight(), true);
+      allHeaders.match((l) {}, (r) {
+        final profile = ProfileParser.parse(
+          tempFilePath: '',
+          profile: RemoteProfileEntity(
+            id: const Uuid().v4(),
+            active: true,
+            name: '',
+            url: validBaseUrl,
+            lastUpdate: DateTime.now(),
+            populatedHeaders: r,
+          ),
+        );
+        expect(profile.isRight(), true);
+        profile.match((l) {}, (r) {
+          expect(r is RemoteProfileEntity, true);
+          r.map(
+            remote: (rp) {
+              expect(rp.subInfo, isNotNull);
+              expect(rp.subInfo!.upload, equals(100));
+              expect(rp.subInfo!.download, equals(200));
+              expect(rp.subInfo!.total, equals(ProfileParser.infiniteTrafficThreshold + 1));
+              expect(
+                rp.subInfo!.expire,
+                equals(DateTime.fromMillisecondsSinceEpoch(ProfileParser.infiniteTimeThreshold * 1000)),
+              );
+              expect(rp.subInfo!.webPageUrl, equals(validBaseUrl));
+              expect(rp.subInfo!.supportUrl, equals(validSupportUrl));
+            },
+            local: (lp) {},
+          );
+        });
+      });
+    });
+
+    test("Should not drop the profile when a subscription-userinfo segment is malformed", () {
+      // A segment without '=' (here "garbage") previously threw and failed the entire profile parse.
+      // It must now be skipped while the valid fields are still parsed.
+      final headers = <String, List<String>>{
+        "profile-title": ["title"],
+        "subscription-userinfo": ["upload=100;download=200;garbage;total=5000;expire=1704054600"],
+      };
+      final fixedHeaders = headers.map((key, value) {
+        if (value.length == 1) return MapEntry(key, value.first);
+        return MapEntry(key, value);
+      });
+      final allHeaders = ProfileParser.populateHeaders(content: '', remoteHeaders: fixedHeaders);
+      expect(allHeaders.isRight(), true);
+      allHeaders.match((l) {}, (r) {
+        final profile = ProfileParser.parse(
+          tempFilePath: '',
+          profile: RemoteProfileEntity(
+            id: const Uuid().v4(),
+            active: true,
+            name: '',
+            url: validBaseUrl,
+            lastUpdate: DateTime.now(),
+            populatedHeaders: r,
+          ),
+        );
+        expect(profile.isRight(), true);
+        profile.match((l) {}, (r) {
+          expect(r is RemoteProfileEntity, true);
+          r.map(
+            remote: (rp) {
+              expect(rp.subInfo, isNotNull);
+              expect(rp.subInfo!.upload, equals(100));
+              expect(rp.subInfo!.download, equals(200));
+              expect(rp.subInfo!.total, equals(5000));
+              expect(
+                rp.subInfo!.expire,
+                equals(DateTime.fromMillisecondsSinceEpoch(1704054600 * 1000)),
+              );
+            },
+            local: (lp) {},
+          );
+        });
+      });
+    });
+
+    test("Should fall back to unlimited traffic when only total is omitted", () {
+      final headers = <String, List<String>>{
+        "profile-title": ["title"],
+        "subscription-userinfo": ["upload=100;download=200;expire=1704054600"],
+      };
+      final fixedHeaders = headers.map((key, value) {
+        if (value.length == 1) return MapEntry(key, value.first);
+        return MapEntry(key, value);
+      });
+      final allHeaders = ProfileParser.populateHeaders(content: '', remoteHeaders: fixedHeaders);
+      expect(allHeaders.isRight(), true);
+      allHeaders.match((l) {}, (r) {
+        final profile = ProfileParser.parse(
+          tempFilePath: '',
+          profile: RemoteProfileEntity(
+            id: const Uuid().v4(),
+            active: true,
+            name: '',
+            url: validBaseUrl,
+            lastUpdate: DateTime.now(),
+            populatedHeaders: r,
+          ),
+        );
+        expect(profile.isRight(), true);
+        profile.match((l) {}, (r) {
+          expect(r is RemoteProfileEntity, true);
+          r.map(
+            remote: (rp) {
+              expect(rp.subInfo, isNotNull);
+              expect(rp.subInfo!.total, equals(ProfileParser.infiniteTrafficThreshold + 1));
+              expect(rp.subInfo!.expire, equals(DateTime.fromMillisecondsSinceEpoch(1704054600 * 1000)));
+            },
+            local: (lp) {},
+          );
+        });
+      });
+    });
+
+    test("Should fall back to no-expiry when only expire is omitted", () {
+      final headers = <String, List<String>>{
+        "profile-title": ["title"],
+        "subscription-userinfo": ["upload=100;download=200;total=5000"],
+      };
+      final fixedHeaders = headers.map((key, value) {
+        if (value.length == 1) return MapEntry(key, value.first);
+        return MapEntry(key, value);
+      });
+      final allHeaders = ProfileParser.populateHeaders(content: '', remoteHeaders: fixedHeaders);
+      expect(allHeaders.isRight(), true);
+      allHeaders.match((l) {}, (r) {
+        final profile = ProfileParser.parse(
+          tempFilePath: '',
+          profile: RemoteProfileEntity(
+            id: const Uuid().v4(),
+            active: true,
+            name: '',
+            url: validBaseUrl,
+            lastUpdate: DateTime.now(),
+            populatedHeaders: r,
+          ),
+        );
+        expect(profile.isRight(), true);
+        profile.match((l) {}, (r) {
+          expect(r is RemoteProfileEntity, true);
+          r.map(
+            remote: (rp) {
+              expect(rp.subInfo, isNotNull);
+              expect(rp.subInfo!.total, equals(5000));
+              expect(
+                rp.subInfo!.expire,
+                equals(DateTime.fromMillisecondsSinceEpoch(ProfileParser.infiniteTimeThreshold * 1000)),
+              );
+            },
+            local: (lp) {},
+          );
+        });
+      });
+    });
+
+    test("Should not throw the whole profile away on non-finite numeric values", () {
+      // num.tryParse of "1e999"/"Infinity"/"NaN" yields a non-finite double; double.toInt() throws on
+      // those. The parser must degrade them gracefully (unlimited sentinels) instead of failing the parse.
+      final headers = <String, List<String>>{
+        "profile-title": ["title"],
+        "subscription-userinfo": ["upload=100;download=200;total=1e999;expire=NaN"],
+      };
+      final fixedHeaders = headers.map((key, value) {
+        if (value.length == 1) return MapEntry(key, value.first);
+        return MapEntry(key, value);
+      });
+      final allHeaders = ProfileParser.populateHeaders(content: '', remoteHeaders: fixedHeaders);
+      expect(allHeaders.isRight(), true);
+      allHeaders.match((l) {}, (r) {
+        final profile = ProfileParser.parse(
+          tempFilePath: '',
+          profile: RemoteProfileEntity(
+            id: const Uuid().v4(),
+            active: true,
+            name: '',
+            url: validBaseUrl,
+            lastUpdate: DateTime.now(),
+            populatedHeaders: r,
+          ),
+        );
+        expect(profile.isRight(), true);
+        profile.match((l) {}, (r) {
+          expect(r is RemoteProfileEntity, true);
+          r.map(
+            remote: (rp) {
+              expect(rp.subInfo, isNotNull);
+              expect(rp.subInfo!.total, equals(ProfileParser.infiniteTrafficThreshold + 1));
+              expect(
+                rp.subInfo!.expire,
+                equals(DateTime.fromMillisecondsSinceEpoch(ProfileParser.infiniteTimeThreshold * 1000)),
+              );
+            },
+            local: (lp) {},
+          );
+        });
+      });
+    });
   });
 }


### PR DESCRIPTION
## Problem

Fixes #2242.

When a panel's `subscription-userinfo` header omits `total` or `expire`, Hiddify discards the **entire** header. That silently removes the usage bar **and** the `support-url` / `profile-web-page-url` tiles, which are parsed in the same pass even though they're unrelated to traffic accounting.

`total` (unlimited plans) and `expire` (no-expiry plans) are routinely omitted by panels — the convention only requires `upload`/`download` — so this hits a lot of real subscriptions.

## Root cause

`lib/features/profile/data/profile_parser.dart`, `_parseSubscriptionInfo`:

```dart
if (map case {"upload": final upload?, "download": final download?, "total": final total, "expire": var expire}) {
  final total1 = (total == null || total == 0) ? infiniteTrafficThreshold + 1 : total;
  expire = (expire == null || expire == 0) ? infiniteTimeThreshold : expire;
  ...
}
return null;
```

Dart map-patterns match on **key presence**. `"total"`/`"expire"` missing from the header → the `case` fails → method returns `null` → populated headers lose usage data, and the `support-url` / `profile-web-page-url` parsed alongside go with it. The body already defaults `total`/`expire` to the unlimited sentinels — the code was written for them to be absent, it just never reaches that branch.

## Fix

Require only `upload`+`download`; read `total`/`expire` from the map as optional:

```diff
- if (map case {"upload": final upload?, "download": final download?, "total": final total, "expire": var expire}) {
+ if (map case {"upload": final upload?, "download": final download?}) {
+   final total = map["total"];
+   var expire = map["expire"];
    final total1 = (total == null || total == 0) ? infiniteTrafficThreshold + 1 : total;
    expire = (expire == null || expire == 0) ? infiniteTimeThreshold : expire;
```

`upload`/`download` stay mandatory. Flow analysis is satisfied — `expire` is reassigned to a non-null value before `expire * 1000`. No behavior change for headers that *do* include all four fields; the unlimited-sentinel defaults are unchanged.

This is independent of #2241 (that one fixes how the unlimited sentinel is *displayed*; this one fixes the header being *parsed at all*). They touch different lines of the same file and don't conflict.
