### PR TITLE
fix(ios): stop forcing VPN on-demand so the native toggle works

### DIFF
--- a/ios/Runner/VPN/VPNManager.swift
+++ b/ios/Runner/VPN/VPNManager.swift
@@ -113,12 +113,10 @@ class VPNManager: ObservableObject {
     
     private func enableVPNManager() async throws {
         manager.isEnabled = true
-        let rule = NEOnDemandRuleConnect()
-        rule.interfaceTypeMatch = .any
-        rule.probeURL = URL(string: "http://captive.apple.com")
-        manager.onDemandRules = [rule]
-        manager.isOnDemandEnabled = true
-        
+        // keep on-demand off so the native iOS VPN toggle can turn the tunnel off
+        manager.onDemandRules = []
+        manager.isOnDemandEnabled = false
+
         do {
             try await manager.saveToPreferences()
             try await manager.loadFromPreferences()


### PR DESCRIPTION
## What's wrong

On iOS, flipping the system VPN switch off (Settings > VPN, or Control Center) while you're connected through Hiddify doesn't actually stop the tunnel. It disconnects and comes right back. So the native on/off control does nothing.

I ran into this on my own device, I haven't seen anyone else report it. But it looks like a bug rather than intended behavior, and the cause is clear, so I figured it was worth a PR.

## Why

On every connect, `VPNManager.enableVPNManager()` installs an on-demand rule and turns it on:

```swift
let rule = NEOnDemandRuleConnect()
rule.interfaceTypeMatch = .any
rule.probeURL = URL(string: "http://captive.apple.com")
manager.onDemandRules = [rule]
manager.isOnDemandEnabled = true
```

`NEOnDemandRuleConnect` with `interfaceTypeMatch = .any` tells iOS the tunnel should always be up. Flip the native switch off and iOS re-checks the rule and reconnects straight away. The only way around it is digging into the VPN profile in Settings and turning off "Connect On Demand" by hand.

## The change

Stop forcing on-demand. `enableVPNManager()` now clears the rules and turns it off, so the native toggle does what people expect. I set it to `false` rather than just deleting the lines so the next connect also wipes any on-demand state left behind by an older build. The cleanup already in `disconnect()` stays, since it covers the case where someone updates the app while the tunnel is running.

```swift
manager.onDemandRules = []
manager.isOnDemandEnabled = false
```

This is iOS only. Android has no on-demand logic (always-on VPN is an OS-level setting there), and macOS runs sing-box as a process with no NetworkExtension, so neither one is affected.

## One thing I want to check with you

I'd rather raise this than decide it on my own. That on-demand rule was also acting as a reconnect / kill switch: if the tunnel drops, iOS brings it back so traffic doesn't go out in the clear. For a circumvention tool that's worth something. The catch is that it was on with no way to turn it off, and it broke the native switch.

Most tap-to-connect iOS VPN apps don't force on-demand, so I just removed it here. If you'd rather keep that safety net, I'm happy to make it a setting instead: off by default so the native switch works, on for anyone who wants the kill switch. Tell me which way you want it and I'll redo it.

## Testing

I couldn't build it locally (no iOS toolchain on my machine). The change only touches `enableVPNManager()` and leaves the rest of the connect/disconnect path alone.
