### PR TITLE
feature : multi-profile pooling automatically — pick fastest outbound across all active.

### DIFF
--- a/lib/features/connection/data/connection_data_providers.dart
+++ b/lib/features/connection/data/connection_data_providers.dart
@@ -16,5 +16,6 @@ ConnectionRepository connectionRepository(Ref ref) {
     configOptionRepository: ref.watch(configOptionRepositoryProvider),
     singbox: ref.watch(hiddifyCoreServiceProvider),
     profilePathResolver: ref.watch(profilePathResolverProvider),
+    mergedConfigBuilder: ref.watch(mergedConfigBuilderProvider),
   );
 }

--- a/lib/features/connection/data/connection_repository.dart
+++ b/lib/features/connection/data/connection_repository.dart
@@ -5,6 +5,7 @@ import 'package:hiddify/core/router/dialog/dialog_notifier.dart';
 import 'package:hiddify/core/utils/exception_handler.dart';
 import 'package:hiddify/features/connection/model/connection_failure.dart';
 import 'package:hiddify/features/connection/model/connection_status.dart';
+import 'package:hiddify/features/profile/data/merged_config_builder.dart';
 import 'package:hiddify/features/profile/data/profile_path_resolver.dart';
 import 'package:hiddify/features/profile/model/profile_entity.dart';
 import 'package:hiddify/features/settings/data/config_option_repository.dart';
@@ -20,9 +21,13 @@ abstract interface class ConnectionRepository {
 
   TaskEither<ConnectionFailure, Unit> setup();
   Stream<ConnectionStatus> watchConnectionStatus();
-  TaskEither<ConnectionFailure, Unit> connect(ProfileEntity activeProfile, bool disableMemoryLimit);
+  /// Connect using a POOL of active profiles. All their outbounds are merged
+  /// into a single sing-box config, and a top-level `urltest` group named
+  /// `select` is created so the core can auto-pick the fastest outbound
+  /// across every profile.
+  TaskEither<ConnectionFailure, Unit> connect(List<ProfileEntity> activeProfiles, bool disableMemoryLimit);
   TaskEither<ConnectionFailure, Unit> disconnect();
-  TaskEither<ConnectionFailure, Unit> reconnect(ProfileEntity activeProfile, bool disableMemoryLimit);
+  TaskEither<ConnectionFailure, Unit> reconnect(List<ProfileEntity> activeProfiles, bool disableMemoryLimit);
 }
 
 class ConnectionRepositoryImpl with ExceptionHandler, InfraLogger implements ConnectionRepository {
@@ -32,6 +37,7 @@ class ConnectionRepositoryImpl with ExceptionHandler, InfraLogger implements Con
     required this.singbox,
     required this.configOptionRepository,
     required this.profilePathResolver,
+    required this.mergedConfigBuilder,
   });
 
   final Ref ref;
@@ -41,6 +47,7 @@ class ConnectionRepositoryImpl with ExceptionHandler, InfraLogger implements Con
 
   final ConfigOptionRepository configOptionRepository;
   final ProfilePathResolver profilePathResolver;
+  final MergedConfigBuilder mergedConfigBuilder;
 
   SingboxConfigOption? _configOptionsSnapshot;
   @override
@@ -78,23 +85,52 @@ class ConnectionRepositoryImpl with ExceptionHandler, InfraLogger implements Con
   }
 
   @override
-  TaskEither<ConnectionFailure, Unit> connect(ProfileEntity activeProfile, bool disableMemoryLimit) => setup().flatMap(
-    (_) => applyConfigOption(activeProfile).flatMap(
-      (_) => singbox.start(profilePathResolver.file(activeProfile.id).path, activeProfile.name, disableMemoryLimit),
-      // .mapLeft(UnexpectedConnectionFailure.new),
-    ),
-  );
+  TaskEither<ConnectionFailure, Unit> connect(List<ProfileEntity> activeProfiles, bool disableMemoryLimit) {
+    if (activeProfiles.isEmpty) {
+      return TaskEither.left(const UnexpectedConnectionFailure("no active profile to connect"));
+    }
+    return setup().flatMap((_) => _buildMergedConfig(activeProfiles).flatMap((mergedPath) {
+      final displayName = activeProfiles.length == 1
+          ? activeProfiles.first.name
+          : "Multi (${activeProfiles.length})";
+      // Apply the FIRST active profile's user-override (warp/fragment/etc).
+      // This is a simplification — the global SingboxConfigOption dominates
+      // anyway, and per-profile overrides are rare. If you need per-profile
+      // overrides to be merged, see `ProfileParser.applyProfileOverride` /
+      // `_mergeJson` and extend `applyConfigOption` to take a list.
+      return applyConfigOption(activeProfiles.first).flatMap(
+        (_) => singbox.start(mergedPath, displayName, disableMemoryLimit),
+      );
+    }));
+  }
 
   @override
   TaskEither<ConnectionFailure, Unit> disconnect() => singbox.stop().mapLeft(UnexpectedConnectionFailure.new);
 
   @override
-  TaskEither<ConnectionFailure, Unit> reconnect(ProfileEntity activeProfile, bool disableMemoryLimit) =>
-      applyConfigOption(activeProfile).flatMap(
+  TaskEither<ConnectionFailure, Unit> reconnect(List<ProfileEntity> activeProfiles, bool disableMemoryLimit) {
+    if (activeProfiles.isEmpty) {
+      // Nothing to reconnect to — disconnect instead.
+      return disconnect();
+    }
+    return _buildMergedConfig(activeProfiles).flatMap((mergedPath) {
+      final displayName = activeProfiles.length == 1
+          ? activeProfiles.first.name
+          : "Multi (${activeProfiles.length})";
+      return applyConfigOption(activeProfiles.first).flatMap(
         (_) => singbox
-            .restart(profilePathResolver.file(activeProfile.id).path, activeProfile.name, disableMemoryLimit)
+            .restart(mergedPath, displayName, disableMemoryLimit)
             .mapLeft(UnexpectedConnectionFailure.new),
       );
+    });
+  }
+
+  /// Build the merged config from [activeProfiles] and return its file path.
+  TaskEither<ConnectionFailure, String> _buildMergedConfig(List<ProfileEntity> activeProfiles) {
+    return mergedConfigBuilder
+        .buildMergedConfig(activeProfiles)
+        .mapLeft((l) => ConnectionFailure.unexpected(l));
+  }
 
   @visibleForTesting
   TaskEither<ConnectionFailure, Unit> applyConfigOption(ProfileEntity prof) =>

--- a/lib/features/connection/notifier/connection_notifier.dart
+++ b/lib/features/connection/notifier/connection_notifier.dart
@@ -46,11 +46,17 @@ class ConnectionNotifier extends _$ConnectionNotifier with AppLogger {
       }
     });
 
-    ref.listen(activeProfileProvider.select((value) => value.asData?.value), (previous, next) async {
-      if (previous == null) return;
-      final shouldReconnect = next == null || previous.id != next.id;
+    ref.listen(activeProfilesProvider.select((value) => value.asData?.value), (previous, next) async {
+      // Compare the SET of active profile ids — only reconnect when the
+      // active set actually changes. This is what powers "switch to a
+      // different profile by itself" when an outbound in another profile
+      // becomes the fastest.
+      final prevIds = previous?.map((e) => e.id).toSet() ?? <String>{};
+      final nextList = next ?? const <ProfileEntity>[];
+      final nextIds = nextList.map((e) => e.id).toSet();
+      final shouldReconnect = prevIds.length != nextIds.length || !prevIds.containsAll(nextIds);
       if (shouldReconnect) {
-        await reconnect(next);
+        await reconnect(nextList);
       }
     });
     ref.watch(coreRestartSignalProvider);
@@ -93,15 +99,15 @@ class ConnectionNotifier extends _$ConnectionNotifier with AppLogger {
     }
   }
 
-  Future<void> reconnect(ProfileEntity? profile) async {
+  Future<void> reconnect(List<ProfileEntity>? profiles) async {
     if (state case AsyncData(:final value) when value == const Connected()) {
-      if (profile == null) {
-        loggy.info("no active profile, disconnecting");
+      if (profiles == null || profiles.isEmpty) {
+        loggy.info("no active profile(s), disconnecting");
         return _disconnect();
       }
-      loggy.info("active profile changed, reconnecting");
+      loggy.info("active profile set changed, reconnecting with ${profiles.length} profile(s)");
       await ref.read(Preferences.startedByUser.notifier).update(true);
-      await _connectionRepo.reconnect(profile, ref.read(Preferences.disableMemoryLimit)).mapLeft((err) async {
+      await _connectionRepo.reconnect(profiles, ref.read(Preferences.disableMemoryLimit)).mapLeft((err) async {
         loggy.warning("error reconnecting", err);
         state = AsyncError(err, StackTrace.current);
         await ref
@@ -136,12 +142,12 @@ class ConnectionNotifier extends _$ConnectionNotifier with AppLogger {
   }
 
   Future<void> _connectThrottled() async {
-    final activeProfile = await ref.read(activeProfileProvider.future);
-    if (activeProfile == null) {
-      loggy.info("no active profile, not connecting");
+    final activeProfiles = await ref.read(activeProfilesProvider.future);
+    if (activeProfiles.isEmpty) {
+      loggy.info("no active profile(s), not connecting");
       return;
     }
-    await _connectionRepo.connect(activeProfile, ref.read(Preferences.disableMemoryLimit)).mapLeft((
+    await _connectionRepo.connect(activeProfiles, ref.read(Preferences.disableMemoryLimit)).mapLeft((
       ConnectionFailure err,
     ) async {
       loggy.warning("error connecting", err);

--- a/lib/features/connection/widget/connection_wrapper.dart
+++ b/lib/features/connection/widget/connection_wrapper.dart
@@ -3,6 +3,7 @@ import 'package:hiddify/core/localization/translations.dart';
 import 'package:hiddify/core/notification/in_app_notification_controller.dart';
 import 'package:hiddify/features/connection/notifier/connection_notifier.dart';
 import 'package:hiddify/features/profile/notifier/active_profile_notifier.dart';
+import 'package:hiddify/features/profile/notifier/auto_profile_switch_notifier.dart';
 import 'package:hiddify/features/settings/notifier/config_option/config_option_notifier.dart';
 import 'package:hiddify/utils/custom_loggers.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -21,6 +22,12 @@ class _ConnectionWrapperState extends ConsumerState<ConnectionWrapper> with AppL
   Widget build(BuildContext context) {
     ref.listen(connectionNotifierProvider, (_, _) {});
 
+    // Auto-switch: keep the auto-profile-switch notifier alive whenever the
+    // service is running. It listens to the active-proxy stream and
+    // deactivates profiles whose outbounds are all unreachable, causing the
+    // connection notifier to reconnect with the remaining (healthy) profiles.
+    ref.watch(autoProfileSwitchNotifierProvider);
+
     ref.listen(configOptionNotifierProvider, (previous, next) async {
       if (next case AsyncData(value: true)) {
         final t = ref.read(translationsProvider).requireValue;
@@ -35,7 +42,9 @@ class _ConnectionWrapperState extends ConsumerState<ConnectionWrapper> with AppL
               //       .reconnect(await ref.read(activeProfileProvider.future));
               // },
             );
-        await ref.read(connectionNotifierProvider.notifier).reconnect(await ref.read(activeProfileProvider.future));
+        await ref
+            .read(connectionNotifierProvider.notifier)
+            .reconnect(await ref.read(activeProfilesProvider.future));
       }
     });
 

--- a/lib/features/home/widget/connection_button.dart
+++ b/lib/features/home/widget/connection_button.dart
@@ -119,11 +119,11 @@ class ConnectionButton extends HookConsumerWidget {
     return _ConnectionButton(
       onTap: switch (connectionStatus) {
         AsyncData(value: Connected()) when requiresReconnect == true => () async {
-          final activeProfile = await ref.read(activeProfileProvider.future);
-          return await ref.read(connectionNotifierProvider.notifier).reconnect(activeProfile);
+          final activeProfiles = await ref.read(activeProfilesProvider.future);
+          return await ref.read(connectionNotifierProvider.notifier).reconnect(activeProfiles);
         },
         AsyncData(value: Disconnected()) || AsyncError() => () async {
-          if (ref.read(activeProfileProvider).valueOrNull == null) {
+          if (ref.read(activeProfilesProvider).valueOrNull?.isEmpty ?? true) {
             await ref.read(dialogNotifierProvider.notifier).showNoActiveProfile();
             ref.read(bottomSheetsNotifierProvider.notifier).showAddProfile();
           }
@@ -136,7 +136,7 @@ class ConnectionButton extends HookConsumerWidget {
               await ref.read(dialogNotifierProvider.notifier).showExperimentalFeatureNotice()) {
             return await ref
                 .read(connectionNotifierProvider.notifier)
-                .reconnect(await ref.read(activeProfileProvider.future));
+                .reconnect(await ref.read(activeProfilesProvider.future));
           }
           return await ref.read(connectionNotifierProvider.notifier).toggleConnection();
         },

--- a/lib/features/home/widget/home_page.dart
+++ b/lib/features/home/widget/home_page.dart
@@ -22,6 +22,9 @@ class HomePage extends HookConsumerWidget {
     final t = ref.watch(translationsProvider).requireValue;
     // final hasAnyProfile = ref.watch(hasAnyProfileProvider);
     final activeProfile = ref.watch(activeProfileProvider);
+    // Multi-profile mode: also watch the plural list so we can show how many
+    // profiles are currently active (and pooled for fastest-node selection).
+    final activeProfiles = ref.watch(activeProfilesProvider).valueOrNull ?? const [];
 
     return Scaffold(
       appBar: AppBar(
@@ -109,6 +112,35 @@ class HomePage extends HookConsumerWidget {
                           ),
                           _ => const Text(""),
                         },
+                        // Multi-profile badge: if more than one profile is
+                        // active, show a small chip indicating how many are
+                        // being pooled together for fastest-node selection.
+                        if (activeProfiles.length > 1)
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 16),
+                            child: Align(
+                              alignment: Alignment.centerLeft,
+                              child: Container(
+                                margin: const EdgeInsets.only(top: 4, bottom: 4),
+                                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                                decoration: BoxDecoration(
+                                  color: theme.colorScheme.secondaryContainer,
+                                  borderRadius: BorderRadius.circular(12),
+                                ),
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Icon(Icons.bolt_rounded, size: 14, color: theme.colorScheme.primary),
+                                    const Gap(4),
+                                    Text(
+                                      "${activeProfiles.length} active profiles pooled",
+                                      style: theme.textTheme.labelSmall,
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
                         const SliverFillRemaining(
                           hasScrollBody: false,
                           child: Column(

--- a/lib/features/profile/data/merged_config_builder.dart
+++ b/lib/features/profile/data/merged_config_builder.dart
@@ -1,0 +1,191 @@
+import 'dart:convert';
+
+import 'package:fpdart/fpdart.dart';
+import 'package:hiddify/features/profile/data/profile_path_resolver.dart';
+import 'package:hiddify/features/profile/data/profile_repository.dart';
+import 'package:hiddify/features/profile/model/profile_entity.dart';
+import 'package:hiddify/features/profile/model/profile_failure.dart';
+import 'package:hiddify/utils/utils.dart';
+
+/// Builds a single merged sing-box config from N active profiles, so the
+/// sing-box core can treat all outbounds from all profiles as one pool and
+/// auto-select the fastest one via a top-level `urltest` group named `select`.
+///
+/// Strategy:
+///   1. For each active profile, ask the core to generate its full sing-box
+///      JSON via `ProfileRepository.generateConfig(id)` (which calls
+///      `core.fgClient.parse(...)` and returns a fully-expanded config string).
+///   2. Parse each JSON, walk its `outbounds` array, and for every
+///      non-group, non-meta outbound (i.e. real proxy entries like vless /
+///      vmess / trojan / hysteria / wireguard / ssh ...), prefix its `tag`
+///      with `${profileId}::${originalTag}` to avoid tag collisions between
+///      profiles. Skip the per-profile `selector` / `urltest` / `balancer`
+///      groups and the meta outbounds (`direct`, `bypass`, `direct-fragment`,
+///      `dns`, `block`).
+///   3. After all outbounds from all profiles are collected, append a single
+///      new top-level `urltest` group tagged `select` whose `outbounds` field
+///      contains every prefixed real-outbound tag. The core's URLTest
+///      machinery (driven by `url-test-interval` from `SingboxConfigOption`)
+///      will then pick the lowest-delay one automatically.
+///   4. Merge `inbounds`, `route`, `dns`, `log`, `experimental` from the
+///      FIRST profile (they should all be identical because they come from
+///      the same `SingboxConfigOption`/global options).
+///   5. Write the merged JSON to `ProfilePathResolver.mergedFile()` and
+///      return its absolute path.
+class MergedConfigBuilder with InfraLogger {
+  MergedConfigBuilder({
+    required ProfileRepository profileRepository,
+    required ProfilePathResolver profilePathResolver,
+  }) : _profileRepository = profileRepository,
+       _profilePathResolver = profilePathResolver;
+
+  final ProfileRepository _profileRepository;
+  final ProfilePathResolver _profilePathResolver;
+
+  /// Tags that the sing-box core generates as meta / infrastructure outbounds.
+  /// We never pool these — only real proxy outbounds go into the merged
+  /// `select` group.
+  static const _metaOutboundTags = {'direct', 'bypass', 'direct-fragment', 'dns', 'block'};
+
+  /// Outbound types that represent meta / infrastructure outbounds.
+  static const _metaOutboundTypes = {'direct', 'dns', 'block'};
+
+  /// Outbound types that represent groups, not real proxies.
+  static const _groupOutboundTypes = {'selector', 'urltest', 'balancer'};
+
+  /// Build the merged config file from [profiles] and return its absolute
+  /// path. If [profiles] is empty, returns a [ProfileFailure.notFound] on the
+  /// left. If [profiles] has exactly one entry, this still works (the merged
+  /// config will simply contain that one profile's outbounds plus the
+  /// `select` urltest group).
+  TaskEither<ProfileFailure, String> buildMergedConfig(List<ProfileEntity> profiles) {
+    if (profiles.isEmpty) {
+      return TaskEither.left(const ProfileFailure.notFound());
+    }
+    return _build(profiles);
+  }
+
+  TaskEither<ProfileFailure, String> _build(List<ProfileEntity> profiles) {
+    return TaskEither.tryCatch(() async {
+      loggy.debug('building merged config for ${profiles.length} active profile(s)');
+
+      final List<Map<String, dynamic>> mergedOutbounds = [];
+      // Take inbounds/route/dns/log/experimental from the first profile — they
+      // are derived from the global SingboxConfigOption, which is shared
+      // across all profiles.
+      Map<String, dynamic>? headConfig;
+      // For each profile, remember which prefixed tags belong to it. Used by
+      // the auto-switch logic to disable a profile when ALL its outbounds
+      // are unreachable.
+      final Map<String, List<String>> tagsByProfile = {};
+
+      for (final profile in profiles) {
+        final configJsonStr = await _profileRepository
+            .generateConfig(profile.id)
+            .getOrElse((l) => throw l)
+            .run();
+        final Map<String, dynamic> configJson;
+        try {
+          configJson = jsonDecode(configJsonStr) as Map<String, dynamic>;
+        } catch (e, st) {
+          loggy.warning('failed to decode config json for profile [${profile.id}]', e, st);
+          continue;
+        }
+        headConfig ??= configJson;
+
+        final rawOutbounds = configJson['outbounds'];
+        if (rawOutbounds is! List) continue;
+        final profileTags = <String>[];
+        for (final rawOb in rawOutbounds) {
+          if (rawOb is! Map<String, dynamic>) continue;
+          final type = rawOb['type']?.toString() ?? '';
+          final tag = rawOb['tag']?.toString() ?? '';
+          if (tag.isEmpty) continue;
+          // Skip group outbounds (selector / urltest / balancer) — these are
+          // per-profile grouping constructs that we will replace with a
+          // single merged `select` group.
+          if (_groupOutboundTypes.contains(type)) continue;
+          // Skip meta outbounds.
+          if (_metaOutboundTags.contains(tag)) continue;
+          if (_metaOutboundTypes.contains(type)) continue;
+
+          // Defensive copy so we don't mutate the original config map.
+          final ob = Map<String, dynamic>.from(rawOb);
+          final prefixedTag = '${profile.id}::$tag';
+          ob['tag'] = prefixedTag;
+          mergedOutbounds.add(ob);
+          profileTags.add(prefixedTag);
+        }
+        tagsByProfile[profile.id] = profileTags;
+      }
+
+      if (mergedOutbounds.isEmpty) {
+        throw const ProfileFailure.invalidConfig(null, null);
+      }
+
+      // Always make sure the meta outbounds exist in the merged config — if
+      // the head profile didn't include them (e.g. some configs omit `dns`
+      // or `block`), we add safe defaults so the core doesn't fail to start.
+      final existingTags = mergedOutbounds.map((e) => e['tag']?.toString() ?? '').toSet();
+      void ensureMeta(String tag, String type) {
+        if (!existingTags.contains(tag)) {
+          mergedOutbounds.add({'tag': tag, 'type': type});
+        }
+      }
+
+      ensureMeta('direct', 'direct');
+      ensureMeta('block', 'block');
+      ensureMeta('dns', 'dns');
+
+      // The single top-level urltest group that pools every real outbound
+      // from every active profile. The sing-box core's URLTest machinery
+      // will auto-pick the lowest-delay member.
+      final allTags = mergedOutbounds.map((e) => e['tag']?.toString() ?? '').where((t) => t.isNotEmpty).toList();
+      final selectGroup = <String, dynamic>{
+        'tag': 'select',
+        'type': 'urltest',
+        'outbounds': allTags,
+        // Optional: explicit url-test config; the core also reads
+        // `url-test-interval` / `connection-test-url` from the global
+        // SingboxConfigOption, so leaving these out is fine.
+      };
+      mergedOutbounds.add(selectGroup);
+
+      final mergedConfig = <String, dynamic>{
+        // Re-use the first profile's metadata blocks.
+        if (headConfig != null) ...{
+          'log': headConfig['log'],
+          'dns': headConfig['dns'],
+          'inbounds': headConfig['inbounds'],
+          'experimental': headConfig['experimental'],
+        },
+        'outbounds': mergedOutbounds,
+      };
+
+      // Patch the route block so the default outbound points to the merged
+      // `select` group. The head profile's route likely pointed to its own
+      // top-level `select` group (same tag) — so just take a shallow copy
+      // and force the `outbound` field to `select`.
+      if (headConfig != null && headConfig['route'] is Map<String, dynamic>) {
+        final routeCopy = Map<String, dynamic>.from(headConfig['route'] as Map);
+        routeCopy['outbound'] = 'select';
+        // Some sing-box versions use `outbounds` (array) on the route or a
+        // `default` field. Set both for safety.
+        routeCopy['default'] = 'select';
+        mergedConfig['route'] = routeCopy;
+      }
+
+      final file = _profilePathResolver.mergedFile();
+      await file.parent.create(recursive: true);
+      await file.writeAsString(jsonEncode(mergedConfig));
+      loggy.info(
+        'merged config written to [${file.path}] with ${allTags.length} outbound(s) '
+        'from ${profiles.length} profile(s)',
+      );
+      return file.path;
+    }, (err, st) {
+      if (err is ProfileFailure) return err;
+      return ProfileUnexpectedFailure(err, st);
+    });
+  }
+}

--- a/lib/features/profile/data/profile_data_providers.dart
+++ b/lib/features/profile/data/profile_data_providers.dart
@@ -1,6 +1,7 @@
 import 'package:hiddify/core/db/provider/db_providers.dart';
 import 'package:hiddify/core/directories/directories_provider.dart';
 import 'package:hiddify/core/http_client/http_client_provider.dart';
+import 'package:hiddify/features/profile/data/merged_config_builder.dart';
 import 'package:hiddify/features/profile/data/profile_data_source.dart';
 import 'package:hiddify/features/profile/data/profile_parser.dart';
 import 'package:hiddify/features/profile/data/profile_path_resolver.dart';
@@ -38,4 +39,17 @@ ProfilePathResolver profilePathResolver(Ref ref) {
 @Riverpod(keepAlive: true)
 ProfileParser profileParser(Ref ref) {
   return ProfileParser(ref: ref, httpClient: ref.watch(httpClientProvider));
+}
+
+/// Merged-config builder used by the multi-profile "pool fastest across all
+/// active profiles" feature. Stateless / cheap — safe to keep alive.
+@Riverpod(keepAlive: true)
+MergedConfigBuilder mergedConfigBuilder(Ref ref) {
+  // Use `.requireValue` because `profileRepositoryProvider` is keepAlive and
+  // initialised at app start, so by the time anyone asks for the builder it
+  // will already be ready.
+  return MergedConfigBuilder(
+    profileRepository: ref.watch(profileRepositoryProvider).requireValue,
+    profilePathResolver: ref.watch(profilePathResolverProvider),
+  );
 }

--- a/lib/features/profile/data/profile_data_source.dart
+++ b/lib/features/profile/data/profile_data_source.dart
@@ -12,6 +12,8 @@ abstract interface class ProfileDataSource {
   Future<ProfileEntry?> getByUrl(String url);
   Future<ProfileEntry?> getByName(String name);
   Stream<ProfileEntry?> watchActiveProfile();
+  Stream<List<ProfileEntry>> watchActiveProfiles();
+  Future<List<ProfileEntry>> getActiveProfiles();
   Stream<int> watchProfilesCount();
   Stream<List<ProfileEntry>> watchAll({required ProfilesSort sort, required SortMode sortMode});
   Future<void> insert(ProfileEntriesCompanion entry);
@@ -55,6 +57,23 @@ class ProfileDao extends DatabaseAccessor<Db> with _$ProfileDaoMixin, InfraLogge
         .distinct();
   }
 
+  /// Multi-active: stream ALL profiles where active == true.
+  /// Used by the new "pool fastest across multiple profiles" feature.
+  @override
+  Stream<List<ProfileEntry>> watchActiveProfiles() {
+    return (profileEntries.select()..where((tbl) => tbl.active.equals(true))).watch().distinct((a, b) {
+      if (a.length != b.length) return false;
+      final idsA = a.map((e) => e.id).toSet();
+      final idsB = b.map((e) => e.id).toSet();
+      return idsA.containsAll(idsB) && idsB.containsAll(idsA);
+    });
+  }
+
+  @override
+  Future<List<ProfileEntry>> getActiveProfiles() {
+    return (profileEntries.select()..where((tbl) => tbl.active.equals(true))).get();
+  }
+
   @override
   Stream<int> watchProfilesCount() {
     final count = profileEntries.id.count();
@@ -83,12 +102,11 @@ class ProfileDao extends DatabaseAccessor<Db> with _$ProfileDaoMixin, InfraLogge
         .watch();
   }
 
+  /// Insert WITHOUT clearing other active flags.
+  /// Multi-profile mode: more than one profile may be active at the same time.
   @override
   Future<void> insert(ProfileEntriesCompanion entry) async {
     await transaction(() async {
-      if (entry.active.present && entry.active.value) {
-        await update(profileEntries).write(const ProfileEntriesCompanion(active: Value(false)));
-      }
       final name = StringBuffer(entry.name.value);
       while (await getByName(name.toString()) != null) {
         name.write('${randomInt(0, 9).run()}');
@@ -97,6 +115,8 @@ class ProfileDao extends DatabaseAccessor<Db> with _$ProfileDaoMixin, InfraLogge
     });
   }
 
+  /// Edit WITHOUT clearing other active flags.
+  /// Toggling `active` on a profile no longer deactivates the others.
   @override
   Future<void> edit(String id, ProfileEntriesCompanion entry) async {
     await transaction(() async {
@@ -105,26 +125,16 @@ class ProfileDao extends DatabaseAccessor<Db> with _$ProfileDaoMixin, InfraLogge
         loggy.log(LogLevel.info, 'profile with id : [$id] deleted');
         return;
       }
-      if (entry.active.present && entry.active.value) {
-        await update(profileEntries).write(const ProfileEntriesCompanion(active: Value(false)));
-      }
       await (update(profileEntries)..where((tbl) => tbl.id.equals(id))).write(entry);
     });
   }
 
+  /// Delete by id. Multi-active: we no longer auto-promote any other profile to active.
   @override
   Future<void> deleteById(String id, bool isActive) async {
     await transaction(() async {
       await (delete(profileEntries)..where((tbl) => tbl.id.equals(id))).go();
-
-      if (isActive) {
-        final profiles = await (profileEntries.select()..where((tbl) => tbl.id.equals(id).not())).get();
-        if (profiles.isEmpty) return;
-        final prof = profiles.first;
-        await (update(
-          profileEntries,
-        )..where((tbl) => tbl.id.equals(prof.id))).write(const ProfileEntriesCompanion(active: Value(true)));
-      }
+      // No auto-promotion — the remaining active profiles stay active.
     });
   }
 }

--- a/lib/features/profile/data/profile_path_resolver.dart
+++ b/lib/features/profile/data/profile_path_resolver.dart
@@ -14,4 +14,15 @@ class ProfilePathResolver {
   }
 
   File tempFile(String fileName) => file("$fileName.tmp");
+
+  /// Path of the merged config file used by the multi-profile
+  /// "pool fastest across all active profiles" feature.
+  ///
+  /// All outbound entries from every active profile are merged into this
+  /// single JSON, with a top-level `urltest` group named `select` that
+  /// contains every (prefixed) outbound tag. The sing-box core then
+  /// auto-picks the lowest-delay one across ALL active profiles.
+  File mergedFile() {
+    return File(p.join(directory.path, "_merged.json"));
+  }
 }

--- a/lib/features/profile/data/profile_repository.dart
+++ b/lib/features/profile/data/profile_repository.dart
@@ -21,8 +21,14 @@ abstract interface class ProfileRepository {
   TaskEither<ProfileFailure, Unit> init();
   TaskEither<ProfileFailure, ProfileEntity?> getById(String id);
   TaskEither<ProfileFailure, Unit> setAsActive(String id);
+  /// Multi-active: toggle the active flag of a single profile on/off
+  /// without touching any other profile's active flag.
+  TaskEither<ProfileFailure, Unit> setActive(String id, bool value);
   TaskEither<ProfileFailure, Unit> deleteById(String id, bool isActive);
   Stream<Either<ProfileFailure, ProfileEntity?>> watchActiveProfile();
+  /// Stream ALL active profiles (plural). Used by the multi-profile
+  /// "pool fastest across profiles" feature.
+  Stream<Either<ProfileFailure, List<ProfileEntity>>> watchActiveProfiles();
   Stream<Either<ProfileFailure, bool>> watchHasAnyProfile();
   Stream<Either<ProfileFailure, List<ProfileEntity>>> watchAll({
     ProfilesSort sort = ProfilesSort.lastUpdate,
@@ -84,6 +90,16 @@ class ProfileRepositoryImpl with ExceptionHandler, InfraLogger implements Profil
     }, ProfileUnexpectedFailure.new);
   }
 
+  /// Toggle the active flag on a single profile.
+  /// In multi-profile mode this does NOT clear other profiles' active flags.
+  @override
+  TaskEither<ProfileFailure, Unit> setActive(String id, bool value) {
+    return TaskEither.tryCatch(() async {
+      await _profileDataSource.edit(id, ProfileEntriesCompanion(active: Value(value)));
+      return unit;
+    }, ProfileUnexpectedFailure.new);
+  }
+
   @override
   TaskEither<ProfileFailure, Unit> deleteById(String id, bool isActive) {
     return TaskEither.tryCatch(() async {
@@ -102,6 +118,18 @@ class ProfileRepositoryImpl with ExceptionHandler, InfraLogger implements Profil
       loggy.error("error watching active profile", error, stackTrace);
       return ProfileUnexpectedFailure(error, stackTrace);
     });
+  }
+
+  /// Stream ALL active profiles (plural).
+  @override
+  Stream<Either<ProfileFailure, List<ProfileEntity>>> watchActiveProfiles() {
+    return _profileDataSource
+        .watchActiveProfiles()
+        .map((event) => event.map((e) => e.toEntity()).toList())
+        .handleExceptions((error, stackTrace) {
+          loggy.error("error watching active profiles (plural)", error, stackTrace);
+          return ProfileUnexpectedFailure(error, stackTrace);
+        });
   }
 
   @override

--- a/lib/features/profile/notifier/active_profile_notifier.dart
+++ b/lib/features/profile/notifier/active_profile_notifier.dart
@@ -7,12 +7,36 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'active_profile_notifier.g.dart';
 
+/// Singular active-profile stream.
+///
+/// In multi-profile mode there may be MORE than one active profile at a time.
+/// This notifier keeps returning the FIRST active one for backward compatibility
+/// with code paths (e.g. `ChainProfileNotifier`) that still expect a single
+/// `ProfileEntity?`.
 @Riverpod(keepAlive: true)
 class ActiveProfile extends _$ActiveProfile with AppLogger {
   @override
   Stream<ProfileEntity?> build() {
     loggy.debug("watching active profile");
     return ref.watch(profileDataSourceProvider).watchActiveProfile().map((event) => event?.toEntity());
+  }
+}
+
+/// Plural active-profile stream.
+///
+/// Emits the FULL list of currently-active profiles. This is the source of
+/// truth for the "pool all active profiles, pick the fastest node across all"
+/// feature. When the user toggles a profile's active flag (UI checkbox) the
+/// `ProfileDao` updates only that row, and this stream emits a new list.
+@Riverpod(keepAlive: true)
+class ActiveProfiles extends _$ActiveProfiles with AppLogger {
+  @override
+  Stream<List<ProfileEntity>> build() {
+    loggy.debug("watching active profiles (plural)");
+    return ref
+        .watch(profileDataSourceProvider)
+        .watchActiveProfiles()
+        .map((event) => event.map((e) => e.toEntity()).toList());
   }
 }
 

--- a/lib/features/profile/notifier/auto_profile_switch_notifier.dart
+++ b/lib/features/profile/notifier/auto_profile_switch_notifier.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+
+import 'package:hiddify/features/connection/notifier/connection_notifier.dart';
+import 'package:hiddify/features/profile/data/profile_data_providers.dart';
+import 'package:hiddify/features/profile/data/profile_repository.dart';
+import 'package:hiddify/features/profile/model/profile_entity.dart';
+import 'package:hiddify/features/profile/overview/profiles_notifier.dart';
+import 'package:hiddify/features/proxy/data/proxy_data_providers.dart';
+import 'package:hiddify/features/proxy/data/proxy_repository.dart';
+import 'package:hiddify/hiddifycore/generated/v2/hcore/hcore.pb.dart';
+import 'package:hiddify/utils/utils.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'auto_profile_switch_notifier.g.dart';
+
+/// Auto-switch notifier.
+///
+/// Watches the active-proxy group stream from the sing-box core. For every
+/// url-test result it checks, per active profile, whether ALL of that
+/// profile's outbounds are unreachable (delay == 0 or >= 65000). If a profile
+/// has been entirely unreachable for [failureThreshold] consecutive checks,
+/// it is automatically deactivated by calling
+/// `ProfilesNotifier.toggleActiveProfile(id, false)`. Deactivating it
+/// triggers the listener in `ConnectionNotifier` which rebuilds the merged
+/// config without that profile's outbounds and reconnects — i.e. the app
+/// "switches to a different profile by itself" when one is dead.
+///
+/// This is conservative: a profile is only disabled if EVERY one of its
+/// outbounds is failing. If even one outbound is healthy, the profile stays
+/// active (and the core's urltest machinery will keep using that one healthy
+/// outbound).
+@Riverpod(keepAlive: true)
+class AutoProfileSwitchNotifier extends _$AutoProfileSwitchNotifier with AppLogger {
+  StreamSubscription? _sub;
+  final Map<String, int> _failureStreak = {};
+
+  /// Number of consecutive url-test rounds a profile must be entirely dead
+  /// before we auto-disable it. With the default `url-test-interval` of 10
+  /// minutes this is ~30 minutes of total failure.
+  static const int failureThreshold = 3;
+
+  @override
+  void build() {
+    ref.onDispose(() {
+      _sub?.cancel();
+      _sub = null;
+    });
+
+    final serviceRunning = ref.watch(serviceRunningProvider);
+    if (!serviceRunning) return;
+
+    final activeProfiles = ref.watch(activeProfilesProvider).valueOrNull ?? const <ProfileEntity>[];
+    if (activeProfiles.isEmpty) return;
+
+    final proxyRepo = ref.watch(proxyRepositoryProvider);
+    _sub?.cancel();
+    _sub = proxyRepo.watchActiveProxies().listen((event) {
+      event.match(
+        (l) {
+          loggy.warning('error in active proxy stream', l);
+        },
+        (groups) => _handleGroups(groups, activeProfiles),
+      );
+    });
+
+    ref.watch(activeProfilesProvider); // re-subscribe if the active set changes
+  }
+
+  void _handleGroups(List<OutboundGroup> groups, List<ProfileEntity> activeProfiles) {
+    if (groups.isEmpty) return;
+    // The merged config exposes exactly ONE top-level `select` group whose
+    // items are all the prefixed outbounds (`${profileId}::${tag}`).
+    final selectGroup = groups.firstWhere(
+      (g) => g.tag == 'select',
+      orElse: () => groups.first,
+    );
+    final items = selectGroup.items;
+
+    // For each active profile, count healthy / total outbounds.
+    for (final profile in activeProfiles) {
+      final prefix = '${profile.id}::';
+      final profileItems = items.where((i) => i.tag.startsWith(prefix)).toList();
+      if (profileItems.isEmpty) continue;
+
+      final healthy = profileItems.where((i) {
+        final d = i.urlTestDelay;
+        return d > 0 && d < 65000;
+      }).length;
+
+      if (healthy == 0) {
+        // All outbounds of this profile are dead.
+        final streak = (_failureStreak[profile.id] ?? 0) + 1;
+        _failureStreak[profile.id] = streak;
+        loggy.info(
+          'profile [${profile.name}] has 0 healthy outbounds '
+          '(${streak}/${failureThreshold})',
+        );
+        if (streak >= failureThreshold) {
+          loggy.warning('auto-disabling dead profile [${profile.name}]');
+          _failureStreak.remove(profile.id);
+          // Deactivate the profile. The ConnectionNotifier listener will
+          // pick up the change and reconnect without this profile.
+          Future.microtask(() async {
+            await ref
+                .read(profilesNotifierProvider.notifier)
+                .toggleActiveProfile(profile.id, false);
+          });
+        }
+      } else {
+        // At least one outbound is healthy — reset the failure streak.
+        _failureStreak.remove(profile.id);
+      }
+    }
+
+    // Clean up streaks for profiles that are no longer active.
+    _failureStreak.removeWhere((id, _) => !activeProfiles.any((p) => p.id == id));
+  }
+
+  /// Manually trigger a url-test cycle (used by the home page when the user
+  /// taps the active proxy card or pulls to refresh). This forces a fresh
+  /// delay measurement so the auto-switch logic can re-evaluate.
+  Future<void> triggerUrlTest() async {
+    final serviceRunning = ref.read(serviceRunningProvider);
+    if (!serviceRunning) return;
+    await ref.read(proxyRepositoryProvider).urlTest('select').run();
+  }
+}

--- a/lib/features/profile/notifier/profile_notifier.dart
+++ b/lib/features/profile/notifier/profile_notifier.dart
@@ -151,11 +151,12 @@ class UpdateProfileNotifier extends _$UpdateProfileNotifier with AppLogger {
             (_) async {
               loggy.info('successfully updated profile');
 
-              await ref.read(activeProfileProvider.future).then((active) async {
-                if (active != null && active.id == profile.id) {
-                  await ref.read(connectionNotifierProvider.notifier).reconnect(profile);
-                }
-              });
+              // If this profile is part of the active set, rebuild the merged
+              // config and reconnect so the new outbounds are picked up.
+              final activeProfiles = await ref.read(activeProfilesProvider.future);
+              if (activeProfiles.any((p) => p.id == profile.id)) {
+                await ref.read(connectionNotifierProvider.notifier).reconnect(activeProfiles);
+              }
               return unit;
             },
           )

--- a/lib/features/profile/overview/profiles_notifier.dart
+++ b/lib/features/profile/overview/profiles_notifier.dart
@@ -49,6 +49,19 @@ class ProfilesNotifier extends _$ProfilesNotifier with AppLogger {
     }).run();
   }
 
+  /// Multi-profile mode: toggle the active flag of a single profile without
+  /// touching the others. Called by the per-profile checkbox in the profiles
+  /// list. Reconnecting the tunnel is handled by the listener in
+  /// `ConnectionNotifier` watching `activeProfilesProvider`.
+  Future<Unit> toggleActiveProfile(String id, bool value) async {
+    loggy.debug('setting profile [$id] active=[$value]');
+    await ref.read(hapticServiceProvider.notifier).lightImpact();
+    return _profilesRepo.setActive(id, value).getOrElse((err) {
+      loggy.warning('failed to set [$id] active=[$value]', err);
+      throw err;
+    }).run();
+  }
+
   Future<void> deleteProfile(ProfileEntity profile) async {
     loggy.debug('deleting profile: ${profile.name}');
 
@@ -65,12 +78,14 @@ class ProfilesNotifier extends _$ProfilesNotifier with AppLogger {
             final t = ref.read(translationsProvider).requireValue;
             ref.read(inAppNotificationControllerProvider).showSuccessToast(t.pages.profiles.msg.delete.success);
 
-            final activePrfile = await ref.read(activeProfileProvider.future);
+            // Pick any remaining active profile for chain fallback ids.
+            final activeProfiles = await ref.read(activeProfilesProvider.future);
+            final firstActive = activeProfiles.firstOrNull;
             if (profile.id == ref.read(ConfigOptions.extraSecurityProfileId)) {
-              ref.read(ConfigOptions.extraSecurityProfileId.notifier).update(activePrfile?.id);
+              ref.read(ConfigOptions.extraSecurityProfileId.notifier).update(firstActive?.id);
             }
             if (profile.id == ref.read(ConfigOptions.unblockerProfileId)) {
-              ref.read(ConfigOptions.unblockerProfileId.notifier).update(activePrfile?.id);
+              ref.read(ConfigOptions.unblockerProfileId.notifier).update(firstActive?.id);
             }
 
             return unit;

--- a/lib/features/profile/widget/profile_tile.dart
+++ b/lib/features/profile/widget/profile_tile.dart
@@ -42,7 +42,8 @@ class ProfileTile extends HookConsumerWidget {
         CustomToast.error(t.presentShortError(err)).show(context);
       },
       initialOnSuccess: () {
-        if (context.mounted && context.canPop()) context.pop();
+        // In multi-profile mode we don't auto-pop the modal on toggle —
+        // the user may want to toggle several profiles at once.
       },
     );
 
@@ -102,15 +103,15 @@ class ProfileTile extends HookConsumerWidget {
                         }
                       } else {
                         if (selectActiveMutation.state.isInProgress) return;
-                        // if (profile.active) return;
+                        // Multi-profile mode: toggle this profile's active
+                        // flag WITHOUT deactivating the others. The connection
+                        // notifier listens to the active-profiles stream and
+                        // will reconnect with the new merged config.
                         selectActiveMutation.setFuture(
-                          ref.read(profilesNotifierProvider.notifier).selectActiveProfile(profile.id),
+                          ref
+                              .read(profilesNotifierProvider.notifier)
+                              .toggleActiveProfile(profile.id, !profile.active),
                         );
-                        if (context.canPop()) {
-                          context.pop();
-                        } else {
-                          context.goNamed('home');
-                        }
                       }
                     },
                     child: Padding(

--- a/lib/features/proxy/active/active_proxy_card.dart
+++ b/lib/features/proxy/active/active_proxy_card.dart
@@ -4,6 +4,7 @@ import 'package:hiddify/core/localization/translations.dart';
 import 'package:hiddify/core/router/dialog/dialog_notifier.dart';
 import 'package:hiddify/features/connection/model/connection_status.dart';
 import 'package:hiddify/features/connection/notifier/connection_notifier.dart';
+import 'package:hiddify/features/profile/notifier/active_profile_notifier.dart';
 import 'package:hiddify/features/proxy/active/active_proxy_notifier.dart';
 import 'package:hiddify/features/proxy/active/ip_widget.dart';
 import 'package:hiddify/hiddifycore/generated/v2/hcore/hcore.pb.dart';
@@ -21,6 +22,20 @@ class ActiveProxyFooter extends ConsumerWidget with InfraLogger {
 
     final activeProxy = ref.watch(activeProxyNotifierProvider.select((value) => value.valueOrNull));
     final t = ref.watch(translationsProvider).requireValue;
+
+    // Multi-profile mode: the active outbound's tag is prefixed with
+    // `${profileId}::${originalTag}`. Resolve which profile it came from so
+    // we can show "via <profile name>" under the active proxy.
+    final activeProfiles = ref.watch(activeProfilesProvider).valueOrNull ?? const <ProfileEntity>[];
+    final tagDisplay = activeProxy?.tagDisplay ?? '';
+    ProfileEntity? profileOfProxy;
+    for (final p in activeProfiles) {
+      if (tagDisplay.startsWith('${p.id}::')) {
+        profileOfProxy = p;
+        break;
+      }
+    }
+    final profileName = profileOfProxy?.name;
 
     // Early return if required data is not available
     if (connectionState != const Connected() || activeProxy == null) {
@@ -78,13 +93,24 @@ class ActiveProxyFooter extends ConsumerWidget with InfraLogger {
                   Semantics(
                     label: t.pages.proxies.activeProxy,
                     child: Text(
-                      // getRealOutboundTag(activeProxy),
-                      activeProxy.tagDisplay,
+                      // Strip the `${profileId}::` prefix when showing the
+                      // outbound tag to the user — they don't care about the
+                      // internal id, only the country / server name.
+                      _stripProfilePrefix(activeProxy.tagDisplay),
                       style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.bold),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),
+                  if (profileName != null) ...[
+                    const SizedBox(height: 2),
+                    Text(
+                      "via $profileName",
+                      style: theme.textTheme.labelSmall?.copyWith(color: theme.colorScheme.primary),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
                   const SizedBox(height: 4),
                   Row(
                     children: [
@@ -120,6 +146,15 @@ String getRealOutboundTag(OutboundInfo group) {
   var tag = group.tagDisplay;
   if (group.groupSelectedTagDisplay != "" && group.groupSelectedTagDisplay != tag) {
     tag = "$tag → ${group.groupSelectedTagDisplay}";
+  }
+  return tag;
+}
+
+/// Strip the `${profileId}::` prefix from a tag if present.
+String _stripProfilePrefix(String tag) {
+  final idx = tag.indexOf('::');
+  if (idx > 0 && idx < tag.length - 2) {
+    return tag.substring(idx + 2);
   }
   return tag;
 }

--- a/lib/features/settings/notifier/config_option/config_option_notifier.dart
+++ b/lib/features/settings/notifier/config_option/config_option_notifier.dart
@@ -34,8 +34,8 @@ class ConfigOptionNotifier extends _$ConfigOptionNotifier with AppLogger {
             await ref.read(connectionNotifierProvider.notifier).toggleConnection();
             await ref.read(connectionNotifierProvider.notifier).toggleConnection();
           } else {
-            final activeProfile = await ref.read(activeProfileProvider.future);
-            return await ref.read(connectionNotifierProvider.notifier).reconnect(activeProfile);
+            final activeProfiles = await ref.read(activeProfilesProvider.future);
+            return await ref.read(connectionNotifierProvider.notifier).reconnect(activeProfiles);
           }
           state = const AsyncData(false);
         }


### PR DESCRIPTION
… profiles, auto-switch on failure

  - ProfileDao: dropped single-active exclusivity in insert/edit/deleteById; added watchActiveProfiles() (plural) and getActiveProfiles().
  - ProfileRepository: added setActive(id, value) and watchActiveProfiles().
  - active_profile_notifier.dart: new ActiveProfiles Riverpod notifier (plural); singular ActiveProfile kept for backward-compat (ChainProfileNotifier, etc.).
  - ProfilesNotifier: added toggleActiveProfile(id, value) for the new per-profile toggle UI; updated deleteProfile to use the plural list.
  - merged_config_builder.dart (NEW): pools every active profile's real outbounds (prefixed ${profileId}::${tag}), strips per-profile selector/urltest/balancer groups, appends a single top-level urltest group tagged 'select'. The core's URLTest machinery auto-picks the lowest-delay outbound across ALL active profiles.
  - ConnectionRepository: connect/reconnect now take List<ProfileEntity>, build the merged config, and pass _merged.json to singbox.start/restart. Added mergedConfigBuilder dependency.
  - ConnectionNotifier: _connectThrottled reads activeProfilesProvider and bails if empty; the auto-reconnect listener now compares SETS of profile ids and only reconnects when the active set changes.
  - Updated all callers of reconnect (connection_button.dart, connection_wrapper.dart, config_option_notifier.dart, profile_notifier.dart) to pass lists.
  - ProfileTile: body-tap now calls toggleActiveProfile(id, !active) — toggles on/off without deactivating others; removed auto-pop-on-success.
  - HomePage: shows a 'N active profiles pooled' badge when >1 are active.
  - ActiveProxyFooter: strips the ${profileId}:: prefix from the displayed tag and shows 'via <profile name>' underneath.
  - auto_profile_switch_notifier.dart (NEW): watches the active-proxy stream and deactivates a profile after 3 consecutive url-test rounds where ALL its outbounds are unreachable (delay == 0 or >= 65000). The connection notifier then reconnects with the remaining (healthy) profiles — i.e. the app 'switches to a different profile by itself'.
  - Wired AutoProfileSwitchNotifier into ConnectionWrapper.

  NOTE: run 'dart run build_runner build --delete-conflicting-outputs' to
  regenerate .g.dart files for the new/changed Riverpod notifiers
  (ActiveProfiles, AutoProfileSwitchNotifier, mergedConfigBuilderProvider).