### PR TITLE
Fix Windows portable ZIP packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ windows-zip-release:
 	mkdir -p Hiddify; \
 	unzip -q "$$ZIP_FILE" -d Hiddify/; \
 	rm "$$ZIP_FILE"; \
-	tar -a -cf "$$FILE_NAME.zip" Hiddify; \
+	7z a -tzip "$$FILE_NAME.zip" Hiddify; \
 	rm -rf Hiddify; \
 	$(GREEN)Successful$(DONE)
 


### PR DESCRIPTION
Fixes #2301.

## What changed

Replace the Windows portable repackaging command:

```sh
tar -a -cf "$FILE_NAME.zip" Hiddify
```

with an explicit ZIP archive command:

```sh
7z a -tzip "$FILE_NAME.zip" Hiddify
```

## Why

The current GitHub Actions Windows build resolves `tar` to GNU tar. GNU tar's `--auto-compress` / `-a` does not support the `.zip` suffix, so it creates an ordinary TAR archive under a `.zip` filename.

The v4.1.1 `Hiddify-Windows-Portable-x64.zip` release asset therefore has a GNU/POSIX TAR header (`Hiddify/` at the start and `ustar` at offset 257) instead of a ZIP signature. Normal Windows ZIP extraction fails as a result.

7-Zip is available on GitHub-hosted Windows runners, and `-tzip` selects the intended format explicitly while preserving the top-level `Hiddify/` directory.

## Validation

- Confirmed the v4.1.1 release asset is detected as `POSIX tar archive (GNU)` from a 1 KiB range request.
- Ran the new command with the official 7-Zip 26.02 CLI against a representative `Hiddify/` directory.
- Confirmed the result begins with `PK\x03\x04`.
- Confirmed Python `zipfile` can read and extract `Hiddify/sample.txt`.
- Confirmed `7z t` reports a successful integrity check.
- Confirmed `make -n windows-zip-release` expands the new command correctly.
- Ran `git diff --check`.

The full Windows application packaging job was not run locally because this checkout is on macOS; the draft PR's Windows CI should provide the platform-level validation.
