### PR TITLE
Default macOS builds to the release core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ CORE_PRODUCT_NAME=hiddify-core
 CORE_NAME=hiddify-lib
 LIB_NAME=hiddify-core
 
+CHANNEL ?= prod
+
 ifeq ($(CHANNEL),prod)
 	CORE_URL=https://github.com/hiddify/hiddify-core/releases/download/v$(core.version)
 else


### PR DESCRIPTION
# Problem
Currently users can see errors in log when using 4.1.1:
```
failed to start background core
```

Message is the same for many problems under the hood.

This PR fixes this specific error in log:
```
fatal: outbound is deprecated in sing-box 1.11.0 and removed in sing-box 1.13.0, use rule actions instead
```
That shows user "failed to start background core" otherwise.

# How to reproduce
- Build Hiddify from main
- Launch
- (I already had some profiles added previously from previous version)
- Try to connect
- See error

# Fix
Sets CHANNEL ?= prod by default.

Previously, running make macos-prepare without an explicit channel downloaded the draft core, which included sing-box 1.13 and broke legacy routing configs.

The stable release core is now used by default.

**Possibly** (because error message is the same for many errors), fixes problems like: #2223 and #2083 at least right now on the fresh main macOS build.