### PR TITLE
fix(windows): restore the previous connection on startup

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -18,6 +18,8 @@ import 'package:hiddify/features/app/widget/app.dart';
 import 'package:hiddify/features/auto_start/notifier/auto_start_notifier.dart';
 import 'package:hiddify/features/chain/model/chain_enum.dart';
 import 'package:hiddify/features/chain/notifier/chain_profile_notifier.dart';
+import 'package:hiddify/features/connection/notifier/connection_notifier.dart';
+import 'package:hiddify/features/connection/notifier/desktop_connection_restore.dart';
 
 import 'package:hiddify/features/log/data/log_data_providers.dart';
 import 'package:hiddify/features/profile/data/profile_data_providers.dart';
@@ -132,10 +134,30 @@ Future<void> lazyBootstrap(WidgetsBinding widgetsBinding, Environment env) async
     ),
   );
 
+  if (PlatformUtils.isWindows) {
+    unawaited(_restoreDesktopConnection(container));
+  }
+
   if (!kIsWeb) {
     FlutterNativeSplash.remove();
   }
   // SentryFlutter.s(DateTime.now().toUtc());
+}
+
+Future<void> _restoreDesktopConnection(ProviderContainer container) async {
+  try {
+    await restoreDesktopConnectionWhenReady(
+      isRestoreRequested: () => container.read(Preferences.startedByUser),
+      waitForFirstReportedCoreStatus: () => container.read(hiddifyCoreServiceProvider).firstReportedCoreStatus,
+      waitForConnectionStatus: () => container.read(connectionNotifierProvider.future),
+      connect: () {
+        Logger.bootstrap.info("restoring previous desktop connection");
+        return container.read(connectionNotifierProvider.notifier).mayConnect();
+      },
+    );
+  } catch (error, stackTrace) {
+    Logger.bootstrap.warning("desktop connection restore failed", error, stackTrace);
+  }
 }
 
 Future<T> _init<T>(String name, Future<T> Function() initializer, {int? timeout}) async {

--- a/lib/features/connection/model/connection_status.dart
+++ b/lib/features/connection/model/connection_status.dart
@@ -23,6 +23,11 @@ sealed class ConnectionStatus with _$ConnectionStatus {
     _ => false,
   };
 
+  bool get canRestoreConnection => switch (this) {
+    Disconnected(connectionFailure: null) => true,
+    _ => false,
+  };
+
   bool get isSwitching => switch (this) {
     Connecting() => true,
     Disconnecting() => true,

--- a/lib/features/connection/notifier/connection_notifier.dart
+++ b/lib/features/connection/notifier/connection_notifier.dart
@@ -124,11 +124,9 @@ class ConnectionNotifier extends _$ConnectionNotifier with AppLogger {
 
   final _singleStart = SingleCall();
 
-  Future<void> _connect() async {
-    _singleStart.run(
-      () async {
-        await _connectThrottled();
-      },
+  Future<void> _connect() {
+    return _singleStart.run<void>(
+      _connectThrottled,
       onIgnored: () {
         loggy.debug("connect called while another connect/disconnect is still running, ignoring");
       },
@@ -178,8 +176,8 @@ bool serviceRunning(Ref ref) {
 class SingleCall {
   bool _running = false;
 
-  Future<T> run<T>(Future<T> Function() task, {required T onIgnored}) async {
-    if (_running) return onIgnored;
+  Future<T> run<T>(Future<T> Function() task, {required T Function() onIgnored}) async {
+    if (_running) return onIgnored();
 
     _running = true;
     try {

--- a/lib/features/connection/notifier/desktop_connection_restore.dart
+++ b/lib/features/connection/notifier/desktop_connection_restore.dart
@@ -1,0 +1,23 @@
+import 'package:hiddify/features/connection/model/connection_status.dart';
+import 'package:hiddify/singbox/model/core_status.dart';
+
+Future<void> restoreDesktopConnectionWhenReady({
+  required bool Function() isRestoreRequested,
+  required Future<CoreStatus> Function() waitForFirstReportedCoreStatus,
+  required Future<ConnectionStatus> Function() waitForConnectionStatus,
+  required Future<void> Function() connect,
+}) async {
+  if (!isRestoreRequested()) return;
+
+  final coreStatus = await waitForFirstReportedCoreStatus();
+  final coreCanRestore = switch (coreStatus) {
+    CoreStopped(alert: null) => true,
+    _ => false,
+  };
+  if (!coreCanRestore) return;
+
+  final connectionStatus = await waitForConnectionStatus();
+  if (!isRestoreRequested() || !connectionStatus.canRestoreConnection) return;
+
+  await connect();
+}

--- a/lib/hiddifycore/hiddify_core_service.dart
+++ b/lib/hiddifycore/hiddify_core_service.dart
@@ -26,15 +26,24 @@ import 'package:hiddify/utils/custom_loggers.dart';
 import 'package:hiddify/utils/platform_utils.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:loggy/loggy.dart' as loggyl;
+import 'package:meta/meta.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:rxdart/rxdart.dart';
 
 class HiddifyCoreService with InfraLogger {
-  HiddifyCoreService(this.ref);
+  HiddifyCoreService(this.ref, {CoreInterface? coreInterface}) : core = coreInterface ?? getCoreInterface() {
+    // Setup can fail before bootstrap starts awaiting this future. Keep an error handler attached so that the cached
+    // failure is not reported as an unhandled asynchronous error; later awaiters still receive the error.
+    firstReportedCoreStatus.ignore();
+  }
+
   final Ref ref;
 
   // CoreHiddifyCoreService() {}
-  final core = getCoreInterface();
+  final CoreInterface core;
+
+  final _firstReportedCoreStatusCompleter = Completer<CoreStatus>();
+  late final Future<CoreStatus> firstReportedCoreStatus = _firstReportedCoreStatusCompleter.future;
 
   CoreStatus currentState = const CoreStatus.stopped();
   final statusController = BehaviorSubject<CoreStatus>();
@@ -94,6 +103,7 @@ class HiddifyCoreService with InfraLogger {
         final setupResponse = await core.setup(directories, debug, 3);
 
         if (setupResponse.isNotEmpty) {
+          _failFirstReportedCoreStatus(StateError(setupResponse));
           return left(setupResponse);
         }
 
@@ -106,7 +116,8 @@ class HiddifyCoreService with InfraLogger {
         await startListeningStatus("bg", core.bgClient);
         // ref.read(coreRestartSignalProvider.notifier).restart();
         return right(unit);
-      } catch (e) {
+      } catch (e, stackTrace) {
+        _failFirstReportedCoreStatus(e, stackTrace);
         return left(e.toString());
       }
     });
@@ -439,38 +450,62 @@ class HiddifyCoreService with InfraLogger {
   }
 
   Future<void> startListeningStatus(String key, CoreClient cc) async {
-    await listenSingle<CoreStatus>(
-      "${key}StatusListener",
-      () => cc
-          .coreInfoListener(Empty(), options: grpcOptions)
-          .doOnCancel(() {
-            loggy.error("status", "Canceld");
-            if (currentState == const CoreStatus.started()) currentState = const CoreStatus.stopped();
-          })
-          .doOnData((event) {
-            loggy.debug("status", event);
-            if (currentState == const CoreStatus.started()) currentState = const CoreStatus.stopped();
-          })
-          .doOnDone(() {
-            loggy.error("status", "done");
-            if (currentState == const CoreStatus.started()) currentState = const CoreStatus.stopped();
-          })
-          .endWith(CoreInfoResponse(coreState: CoreStates.STOPPED))
-          .map((event) {
-            currentState = CoreStatus.fromCoreInfo(event);
-            statusController.add(currentState);
-            return currentState;
-          }),
-      // .endWith(const CoreStatus.stopped())
-      onError: (error) {
-        loggy.error("Stream error in ${key}StatusListener: $error");
+    await startListeningStatusStream(key, () => cc.coreInfoListener(Empty(), options: grpcOptions));
+  }
 
-        // currentState = const CoreStatus.stopped();
-        // statusController.add(currentState);
+  @visibleForTesting
+  Future<void> startListeningStatusStream(String key, Stream<CoreInfoResponse> Function() statusStream) async {
+    try {
+      await listenSingle<CoreStatus>(
+        "${key}StatusListener",
+        () => statusStream()
+            .doOnCancel(() {
+              loggy.error("status", "Canceld");
+              if (currentState == const CoreStatus.started()) currentState = const CoreStatus.stopped();
+            })
+            .doOnData((event) {
+              loggy.debug("status", event);
+              _reportFirstCoreStatus(CoreStatus.fromCoreInfo(event));
+              if (currentState == const CoreStatus.started()) currentState = const CoreStatus.stopped();
+            })
+            .doOnDone(() {
+              loggy.error("status", "done");
+              _failFirstReportedCoreStatus(StateError("core status listener ended before reporting a status"));
+              if (currentState == const CoreStatus.started()) currentState = const CoreStatus.stopped();
+            })
+            .endWith(CoreInfoResponse(coreState: CoreStates.STOPPED))
+            .map((event) {
+              currentState = CoreStatus.fromCoreInfo(event);
+              statusController.add(currentState);
+              return currentState;
+            }),
+        // .endWith(const CoreStatus.stopped())
+        onError: (error, stackTrace) {
+          loggy.error("Stream error in ${key}StatusListener: $error");
+          _failFirstReportedCoreStatus(error, stackTrace);
 
-        // startListeningStatus(key, cc);
-      },
-    );
+          // currentState = const CoreStatus.stopped();
+          // statusController.add(currentState);
+
+          // startListeningStatus(key, cc);
+        },
+      );
+    } catch (error, stackTrace) {
+      _failFirstReportedCoreStatus(error, stackTrace);
+      rethrow;
+    }
+  }
+
+  void _reportFirstCoreStatus(CoreStatus status) {
+    if (!_firstReportedCoreStatusCompleter.isCompleted) {
+      _firstReportedCoreStatusCompleter.complete(status);
+    }
+  }
+
+  void _failFirstReportedCoreStatus(Object error, [StackTrace? stackTrace]) {
+    if (!_firstReportedCoreStatusCompleter.isCompleted) {
+      _firstReportedCoreStatusCompleter.completeError(error, stackTrace ?? StackTrace.current);
+    }
   }
 
   Future<void> startListeningLogs(String key, CoreClient cc) async {
@@ -514,7 +549,7 @@ class HiddifyCoreService with InfraLogger {
   Future<StreamSubscription<T>?> listenSingle<T>(
     String key,
     Stream<T> Function() stream, {
-    Function(dynamic error)? onError,
+    void Function(Object error, StackTrace stackTrace)? onError,
   }) async {
     if (subscriptions.containsKey(key)) {
       // return subscriptions[key] as StreamSubscription<T>?;
@@ -526,9 +561,9 @@ class HiddifyCoreService with InfraLogger {
         // loggy.debug(event);
       },
       cancelOnError: true,
-      onError: (error) {
+      onError: (Object error, StackTrace stackTrace) {
         loggy.log(loggyl.LogLevel.error, 'Stream error: $error');
-        onError?.call(error);
+        onError?.call(error, stackTrace);
         subscriptions[key]?.cancel();
         subscriptions.remove(key);
       },

--- a/test/features/connection/model/connection_status_test.dart
+++ b/test/features/connection/model/connection_status_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hiddify/features/connection/model/connection_failure.dart';
+import 'package:hiddify/features/connection/model/connection_status.dart';
+
+void main() {
+  group("canRestoreConnection", () {
+    test("allows a normal disconnected state", () {
+      expect(const ConnectionStatus.disconnected().canRestoreConnection, isTrue);
+    });
+
+    test("rejects a disconnected state with a failure", () {
+      expect(
+        const ConnectionStatus.disconnected(ConnectionFailure.unexpected("startup failed")).canRestoreConnection,
+        isFalse,
+      );
+    });
+
+    test("rejects active and transitional states", () {
+      expect(const ConnectionStatus.connecting().canRestoreConnection, isFalse);
+      expect(const ConnectionStatus.connected().canRestoreConnection, isFalse);
+      expect(const ConnectionStatus.disconnecting().canRestoreConnection, isFalse);
+    });
+  });
+}

--- a/test/features/connection/notifier/connection_notifier_test.dart
+++ b/test/features/connection/notifier/connection_notifier_test.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:hiddify/core/preferences/preferences_provider.dart';
+import 'package:hiddify/features/connection/data/connection_data_providers.dart';
+import 'package:hiddify/features/connection/data/connection_repository.dart';
+import 'package:hiddify/features/connection/model/connection_failure.dart';
+import 'package:hiddify/features/connection/model/connection_status.dart';
+import 'package:hiddify/features/connection/notifier/connection_notifier.dart';
+import 'package:hiddify/features/profile/model/profile_entity.dart';
+import 'package:hiddify/features/profile/notifier/active_profile_notifier.dart';
+import 'package:hiddify/singbox/model/singbox_config_option.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test("mayConnect completes only after the repository connection completes", () async {
+    SharedPreferences.setMockInitialValues(const {});
+    final preferences = await SharedPreferences.getInstance();
+    final profile = ProfileEntity.local(
+      id: "profile-id",
+      active: true,
+      name: "test profile",
+      lastUpdate: DateTime(2026),
+    );
+    final repository = _BlockingConnectionRepository();
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWith((ref) => preferences),
+        connectionRepositoryProvider.overrideWithValue(repository),
+        activeProfileProvider.overrideWith(() => _FakeActiveProfile(profile)),
+      ],
+    );
+    addTearDown(() {
+      repository.completeAllConnections();
+      container.dispose();
+    });
+
+    await container.read(sharedPreferencesProvider.future);
+    expect(await container.read(connectionNotifierProvider.future), const ConnectionStatus.disconnected());
+
+    var completed = false;
+    final connection = container.read(connectionNotifierProvider.notifier).mayConnect().whenComplete(() {
+      completed = true;
+    });
+    await Future<void>.delayed(Duration.zero);
+
+    expect(repository.connectCalls, 1);
+    expect(completed, isFalse);
+
+    repository.completeConnection();
+    await connection;
+    expect(completed, isTrue);
+  });
+
+  test("concurrent mayConnect calls are ignored while a later call can run", () async {
+    SharedPreferences.setMockInitialValues(const {});
+    final preferences = await SharedPreferences.getInstance();
+    final profile = ProfileEntity.local(
+      id: "profile-id",
+      active: true,
+      name: "test profile",
+      lastUpdate: DateTime(2026),
+    );
+    final repository = _BlockingConnectionRepository();
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWith((ref) => preferences),
+        connectionRepositoryProvider.overrideWithValue(repository),
+        activeProfileProvider.overrideWith(() => _FakeActiveProfile(profile)),
+      ],
+    );
+    addTearDown(() {
+      repository.completeAllConnections();
+      container.dispose();
+    });
+
+    await container.read(sharedPreferencesProvider.future);
+    expect(await container.read(connectionNotifierProvider.future), const ConnectionStatus.disconnected());
+
+    final first = container.read(connectionNotifierProvider.notifier).mayConnect();
+    final concurrent = container.read(connectionNotifierProvider.notifier).mayConnect();
+    await Future<void>.delayed(Duration.zero);
+    expect(repository.connectCalls, 1);
+
+    await concurrent;
+    expect(repository.connectCalls, 1);
+
+    repository.completeConnection();
+    await first;
+
+    final later = container.read(connectionNotifierProvider.notifier).mayConnect();
+    await Future<void>.delayed(Duration.zero);
+    expect(repository.connectCalls, 2);
+
+    repository.completeConnection();
+    await later;
+  });
+}
+
+class _FakeActiveProfile extends ActiveProfile {
+  _FakeActiveProfile(this.profile);
+
+  final ProfileEntity profile;
+
+  @override
+  Stream<ProfileEntity?> build() => Stream.value(profile);
+}
+
+class _BlockingConnectionRepository implements ConnectionRepository {
+  final _connections = <Completer<void>>[];
+
+  int connectCalls = 0;
+
+  void completeConnection() {
+    final connection = _connections.firstWhere((connection) => !connection.isCompleted);
+    connection.complete();
+  }
+
+  void completeAllConnections() {
+    for (final connection in _connections) {
+      if (!connection.isCompleted) connection.complete();
+    }
+  }
+
+  @override
+  SingboxConfigOption? get configOptionsSnapshot => null;
+
+  @override
+  TaskEither<ConnectionFailure, Unit> setup() => TaskEither.of(unit);
+
+  @override
+  Stream<ConnectionStatus> watchConnectionStatus() => Stream.value(const ConnectionStatus.disconnected());
+
+  @override
+  TaskEither<ConnectionFailure, Unit> connect(ProfileEntity activeProfile, bool disableMemoryLimit) {
+    return TaskEither(() async {
+      connectCalls++;
+      final connection = Completer<void>();
+      _connections.add(connection);
+      await connection.future;
+      return right(unit);
+    });
+  }
+
+  @override
+  TaskEither<ConnectionFailure, Unit> disconnect() => TaskEither.of(unit);
+
+  @override
+  TaskEither<ConnectionFailure, Unit> reconnect(ProfileEntity activeProfile, bool disableMemoryLimit) {
+    return TaskEither.of(unit);
+  }
+}

--- a/test/features/connection/notifier/desktop_connection_restore_test.dart
+++ b/test/features/connection/notifier/desktop_connection_restore_test.dart
@@ -1,0 +1,144 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hiddify/features/connection/model/connection_failure.dart';
+import 'package:hiddify/features/connection/model/connection_status.dart';
+import 'package:hiddify/features/connection/notifier/desktop_connection_restore.dart';
+import 'package:hiddify/singbox/model/core_status.dart';
+
+void main() {
+  test("does not wait for core status when restore was not requested", () async {
+    var waitedForCoreStatus = false;
+
+    await restoreDesktopConnectionWhenReady(
+      isRestoreRequested: () => false,
+      waitForFirstReportedCoreStatus: () {
+        waitedForCoreStatus = true;
+        return Future.value(const CoreStatus.stopped());
+      },
+      waitForConnectionStatus: () => Future.value(const ConnectionStatus.disconnected()),
+      connect: () => Future.value(),
+    );
+
+    expect(waitedForCoreStatus, isFalse);
+  });
+
+  test("waits for real core and connection states and for connect completion", () async {
+    final coreStatus = Completer<CoreStatus>();
+    final connectionStatus = Completer<ConnectionStatus>();
+    final connection = Completer<void>();
+    var waitedForConnectionStatus = false;
+    var connectCalls = 0;
+    var completed = false;
+
+    final restore = restoreDesktopConnectionWhenReady(
+      isRestoreRequested: () => true,
+      waitForFirstReportedCoreStatus: () => coreStatus.future,
+      waitForConnectionStatus: () {
+        waitedForConnectionStatus = true;
+        return connectionStatus.future;
+      },
+      connect: () {
+        connectCalls++;
+        return connection.future;
+      },
+    ).whenComplete(() => completed = true);
+
+    await Future<void>.delayed(Duration.zero);
+    expect(waitedForConnectionStatus, isFalse);
+    expect(connectCalls, 0);
+
+    coreStatus.complete(const CoreStatus.stopped());
+    await Future<void>.delayed(Duration.zero);
+    expect(waitedForConnectionStatus, isTrue);
+    expect(connectCalls, 0);
+
+    connectionStatus.complete(const ConnectionStatus.disconnected());
+    await Future<void>.delayed(Duration.zero);
+    expect(connectCalls, 1);
+    expect(completed, isFalse);
+
+    connection.complete();
+    await restore;
+    expect(completed, isTrue);
+  });
+
+  for (final coreStatus in <CoreStatus>[
+    const CoreStatus.starting(),
+    const CoreStatus.started(),
+    const CoreStatus.stopping(),
+    const CoreStatus.stopped(alert: CoreAlert.startFailed),
+  ]) {
+    test("does not restore from ${coreStatus.runtimeType}", () async {
+      var waitedForConnectionStatus = false;
+      var connectCalls = 0;
+
+      await restoreDesktopConnectionWhenReady(
+        isRestoreRequested: () => true,
+        waitForFirstReportedCoreStatus: () => Future.value(coreStatus),
+        waitForConnectionStatus: () {
+          waitedForConnectionStatus = true;
+          return Future.value(const ConnectionStatus.disconnected());
+        },
+        connect: () async {
+          connectCalls++;
+        },
+      );
+
+      expect(waitedForConnectionStatus, isFalse);
+      expect(connectCalls, 0);
+    });
+  }
+
+  test("rechecks restore preference after waiting for connection state", () async {
+    var restoreRequested = true;
+    var connectCalls = 0;
+    final connectionStatus = Completer<ConnectionStatus>();
+
+    final restore = restoreDesktopConnectionWhenReady(
+      isRestoreRequested: () => restoreRequested,
+      waitForFirstReportedCoreStatus: () => Future.value(const CoreStatus.stopped()),
+      waitForConnectionStatus: () => connectionStatus.future,
+      connect: () async {
+        connectCalls++;
+      },
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    restoreRequested = false;
+    connectionStatus.complete(const ConnectionStatus.disconnected());
+    await restore;
+
+    expect(connectCalls, 0);
+  });
+
+  test("does not restore a disconnected state with a failure", () async {
+    var connectCalls = 0;
+
+    await restoreDesktopConnectionWhenReady(
+      isRestoreRequested: () => true,
+      waitForFirstReportedCoreStatus: () => Future.value(const CoreStatus.stopped()),
+      waitForConnectionStatus: () =>
+          Future.value(const ConnectionStatus.disconnected(ConnectionFailure.unexpected("startup failed"))),
+      connect: () async {
+        connectCalls++;
+      },
+    );
+
+    expect(connectCalls, 0);
+  });
+
+  test("propagates a failure reported before the first core status", () async {
+    final error = StateError("core setup failed");
+
+    await expectLater(
+      restoreDesktopConnectionWhenReady(
+        isRestoreRequested: () => true,
+        waitForFirstReportedCoreStatus: () => Future.error(error),
+        waitForConnectionStatus: () => Future.value(const ConnectionStatus.disconnected()),
+        connect: () => Future.value(),
+      ),
+      throwsA(same(error)),
+    );
+  });
+}

--- a/test/hiddifycore/hiddify_core_service_status_test.dart
+++ b/test/hiddifycore/hiddify_core_service_status_test.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hiddify/core/directories/directories_provider.dart';
+import 'package:hiddify/core/model/directories.dart';
+import 'package:hiddify/core/preferences/general_preferences.dart';
+import 'package:hiddify/hiddifycore/core_interface/core_interface.dart';
+import 'package:hiddify/hiddifycore/generated/v2/hcore/hcore.pb.dart';
+import 'package:hiddify/hiddifycore/hiddify_core_service.dart';
+import 'package:hiddify/singbox/model/core_status.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  test("firstReportedCoreStatus uses the first real listener event only", () async {
+    final fixture = _ServiceFixture();
+    addTearDown(fixture.dispose);
+    final statuses = StreamController<CoreInfoResponse>();
+    fixture.controllers.add(statuses);
+
+    await fixture.service.startListeningStatusStream("bg", () => statuses.stream);
+    statuses.add(CoreInfoResponse(coreState: CoreStates.STARTING));
+
+    expect(await fixture.service.firstReportedCoreStatus, const CoreStatus.starting());
+
+    statuses.add(CoreInfoResponse(coreState: CoreStates.STARTED));
+    await Future<void>.delayed(Duration.zero);
+    expect(await fixture.service.firstReportedCoreStatus, const CoreStatus.starting());
+    expect(fixture.service.currentState, const CoreStatus.started());
+  });
+
+  test("synthetic stopped event does not satisfy firstReportedCoreStatus", () async {
+    final fixture = _ServiceFixture();
+    addTearDown(fixture.dispose);
+    final statuses = StreamController<CoreInfoResponse>();
+    fixture.controllers.add(statuses);
+    final syntheticStatus = fixture.service.statusController.first;
+
+    await fixture.service.startListeningStatusStream("bg", () => statuses.stream);
+    await statuses.close();
+
+    expect(await syntheticStatus, isA<CoreStopped>().having((status) => status.alert, "alert", isNull));
+    await expectLater(fixture.service.firstReportedCoreStatus, throwsA(isA<StateError>()));
+  });
+
+  test("listener error fails firstReportedCoreStatus", () async {
+    final fixture = _ServiceFixture();
+    addTearDown(fixture.dispose);
+    final statuses = StreamController<CoreInfoResponse>();
+    fixture.controllers.add(statuses);
+    final error = StateError("listener failed");
+
+    await fixture.service.startListeningStatusStream("bg", () => statuses.stream);
+    statuses.addError(error, StackTrace.current);
+
+    await expectLater(fixture.service.firstReportedCoreStatus, throwsA(same(error)));
+  });
+
+  test("synchronous listener setup error fails firstReportedCoreStatus", () async {
+    final fixture = _ServiceFixture();
+    addTearDown(fixture.dispose);
+    final error = StateError("listener setup failed");
+
+    await expectLater(fixture.service.startListeningStatusStream("bg", () => throw error), throwsA(same(error)));
+    await expectLater(fixture.service.firstReportedCoreStatus, throwsA(same(error)));
+  });
+
+  test("core setup error fails firstReportedCoreStatus", () async {
+    final fixture = _ServiceFixture(coreInterface: _FailingSetupCoreInterface());
+    addTearDown(fixture.dispose);
+
+    final result = await fixture.service.setup().run();
+
+    expect(result.isLeft(), isTrue);
+    await expectLater(fixture.service.firstReportedCoreStatus, throwsA(isA<StateError>()));
+  });
+}
+
+class _ServiceFixture {
+  _ServiceFixture({CoreInterface? coreInterface}) {
+    final serviceProvider = Provider<HiddifyCoreService>(
+      (ref) => HiddifyCoreService(ref, coreInterface: coreInterface ?? CoreInterface()),
+    );
+    container = ProviderContainer(
+      overrides: [
+        appDirectoriesProvider.overrideWith(_FakeAppDirectories.new),
+        debugModeNotifierProvider.overrideWith(_FakeDebugModeNotifier.new),
+      ],
+    );
+    service = container.read(serviceProvider);
+  }
+
+  late final ProviderContainer container;
+  late final HiddifyCoreService service;
+  final controllers = <StreamController<CoreInfoResponse>>[];
+
+  Future<void> dispose() async {
+    for (final controller in controllers) {
+      if (!controller.isClosed) await controller.close();
+    }
+    await service.stopListenSingle("");
+    await service.statusController.close();
+    container.dispose();
+  }
+}
+
+class _FakeAppDirectories extends AppDirectories {
+  @override
+  Future<Directories> build() async => (baseDir: Directory("."), workingDir: Directory("."), tempDir: Directory("."));
+}
+
+class _FakeDebugModeNotifier extends DebugModeNotifier {
+  @override
+  bool build() => false;
+}
+
+class _FailingSetupCoreInterface extends CoreInterface {
+  @override
+  Future<String> setup(Directories directories, bool debug, int mode) async => "core setup failed";
+}


### PR DESCRIPTION
## Summary

- restore the previous Windows connection only when it was intentionally left connected by the user
- wait for the first status actually reported by Core instead of treating the synthetic initial status or a fixed delay as readiness
- reconnect only from a clean stopped and disconnected state, then recheck the saved preference immediately before connecting
- await the underlying connection attempt while continuing to serialize duplicate connect calls

This PR is limited to restoring the previous connection during Windows startup. It does not implement reconnection after network changes or split tunneling.

## Testing

- `flutter test --no-pub test/features/connection/model/connection_status_test.dart test/features/connection/notifier/connection_notifier_test.dart test/features/connection/notifier/desktop_connection_restore_test.dart test/hiddifycore/hiddify_core_service_status_test.dart` (19 tests)
- `flutter test --no-pub` (44 tests)
- `flutter analyze --no-pub` (reports the repository's existing analyzer baseline; no new production errors found)
- Fork Windows build: https://github.com/LiuLin1220/hiddify-app/actions/runs/31926154984
- [ ] Windows startup smoke test with startup and silent launch enabled

## References

- Partially addresses #2280 (startup auto-connect only).
- Follow-up to #2076 and #2198, which were closed automatically as stale.