### PR TITLE
fix(logs): emit an initial snapshot without ending the stream

### DIFF
--- a/lib/hiddifycore/hiddify_core_service.dart
+++ b/lib/hiddifycore/hiddify_core_service.dart
@@ -38,7 +38,7 @@ class HiddifyCoreService with InfraLogger {
 
   CoreStatus currentState = const CoreStatus.stopped();
   final statusController = BehaviorSubject<CoreStatus>();
-  final logController = BehaviorSubject<List<LogMessage>>();
+  final logController = BehaviorSubject<List<LogMessage>>.seeded(const []);
   final CallOptions? grpcOptions = null; //CallOptions(timeout: const Duration(milliseconds: 10000));
   final Map<String, StreamSubscription?> subscriptions = {};
   List<OutboundGroup> latest = [];
@@ -367,11 +367,11 @@ class HiddifyCoreService with InfraLogger {
 
   Stream<List<LogMessage>> watchLogs(String path) async* {
     if (!core.isInitialized()) {
-      loggy.debug("core is not initialized, returning empty log stream");
-      return;
+      loggy.debug("core is not initialized, waiting for log snapshots");
+    } else {
+      await startListeningLogs("bg", core.bgClient);
+      await startListeningLogs("fg", core.fgClient);
     }
-    await startListeningLogs("bg", core.bgClient);
-    await startListeningLogs("fg", core.fgClient);
     try {
       yield* logController.stream;
     } catch (e) {
@@ -401,6 +401,7 @@ class HiddifyCoreService with InfraLogger {
     return TaskEither(() async {
       loggy.debug("clearing logs");
       logBuffer.clear();
+      logController.add(const []);
       // final res = await core.bgClient(Empty());
       // if (res.code != ResponseCode.OK) return left("${res.code} ${res.message}");
       return right(unit);
@@ -485,7 +486,7 @@ class HiddifyCoreService with InfraLogger {
         if (logBuffer.length > 300) {
           logBuffer.removeAt(0);
         }
-        logController.add(logBuffer);
+        logController.add(List<LogMessage>.unmodifiable(logBuffer));
         // loggy.log(getLogLevel(event.level), event.message);
         event.message.split('\n').forEach((line) {
           loggy.log(getLogLevel(event.level), line);

--- a/test/features/log/overview/logs_overview_notifier_test.dart
+++ b/test/features/log/overview/logs_overview_notifier_test.dart
@@ -1,0 +1,43 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:hiddify/features/log/data/log_data_providers.dart';
+import 'package:hiddify/features/log/data/log_repository.dart';
+import 'package:hiddify/features/log/model/log_entity.dart';
+import 'package:hiddify/features/log/model/log_failure.dart';
+import 'package:hiddify/features/log/overview/logs_overview_notifier.dart';
+import 'package:hiddify/features/log/overview/logs_overview_state.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  test("an empty initial log snapshot resolves the loading state", () async {
+    final repository = _EmptyLogRepository();
+    final container = ProviderContainer(overrides: [logRepositoryProvider.overrideWith((ref) => repository)]);
+    addTearDown(container.dispose);
+    await container.read(logRepositoryProvider.future);
+
+    final dataState = Completer<LogsOverviewState>();
+    final subscription = container.listen(logsOverviewNotifierProvider, (previous, next) {
+      if (next.logs.hasValue && !dataState.isCompleted) {
+        dataState.complete(next);
+      }
+    }, fireImmediately: true);
+    addTearDown(subscription.close);
+
+    final state = await dataState.future.timeout(const Duration(seconds: 2));
+
+    expect(state.logs.requireValue, isEmpty);
+  });
+}
+
+class _EmptyLogRepository implements LogRepository {
+  @override
+  TaskEither<LogFailure, Unit> init() => TaskEither.of(unit);
+
+  @override
+  Stream<Either<LogFailure, List<LogEntity>>> watchLogs() => Stream.value(right([]));
+
+  @override
+  TaskEither<LogFailure, Unit> clearLogs() => TaskEither.of(unit);
+}

--- a/test/hiddifycore/hiddify_core_service_test.dart
+++ b/test/hiddifycore/hiddify_core_service_test.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grpc/grpc.dart';
+import 'package:hiddify/core/preferences/preferences_provider.dart';
+import 'package:hiddify/hiddifycore/generated/v2/hcore/hcore.pb.dart';
+import 'package:hiddify/hiddifycore/generated/v2/hcore/hcore_service.pbgrpc.dart';
+import 'package:hiddify/hiddifycore/hiddify_core_service.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  late ProviderContainer container;
+  late HiddifyCoreService service;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final preferences = await SharedPreferences.getInstance();
+    final serviceProvider = Provider<HiddifyCoreService>(HiddifyCoreService.new);
+    container = ProviderContainer(overrides: [sharedPreferencesProvider.overrideWith((ref) => preferences)]);
+    await container.read(sharedPreferencesProvider.future);
+    service = container.read(serviceProvider);
+  });
+
+  tearDown(() async {
+    for (final subscription in service.subscriptions.values) {
+      await subscription?.cancel();
+    }
+    await service.logController.close();
+    await service.statusController.close();
+    container.dispose();
+  });
+
+  test("watchLogs emits the initial empty snapshot exactly once", () async {
+    final message = LogMessage(message: "first");
+    final snapshotsFuture = service.watchLogs("unused").take(2).toList();
+
+    await pumpEventQueue();
+    service.logController.add(List<LogMessage>.unmodifiable([message]));
+
+    final snapshots = await snapshotsFuture.timeout(const Duration(seconds: 1));
+
+    expect(snapshots, [
+      isEmpty,
+      [message],
+    ]);
+  });
+
+  test("log controller starts with an empty snapshot", () {
+    expect(service.logController.value, isEmpty);
+  });
+
+  test("watchLogs replays the current cached snapshot", () async {
+    final message = LogMessage(message: "cached");
+    service.logController.add(List<LogMessage>.unmodifiable([message]));
+
+    final logs = await service.watchLogs("unused").first.timeout(const Duration(seconds: 1));
+
+    expect(logs, [message]);
+  });
+
+  test("watchLogs stays alive while core is not initialized", () async {
+    final message = LogMessage(message: "later");
+    final snapshotsFuture = service.watchLogs("unused").take(2).toList();
+
+    await pumpEventQueue();
+    service.logController.add(List<LogMessage>.unmodifiable([message]));
+
+    final snapshots = await snapshotsFuture.timeout(const Duration(seconds: 1));
+    expect(snapshots.last, [message]);
+  });
+
+  test("clearLogs publishes the cleared snapshot", () async {
+    final stale = LogMessage(message: "stale");
+    service.logBuffer.add(stale);
+    service.logController.add(List<LogMessage>.unmodifiable(service.logBuffer));
+    final snapshotsFuture = service.watchLogs("unused").take(2).toList();
+
+    await pumpEventQueue();
+
+    final result = await service.clearLogs().run();
+    final snapshots = await snapshotsFuture.timeout(const Duration(seconds: 1));
+
+    expect(result.isRight(), isTrue);
+    expect(service.logBuffer, isEmpty);
+    expect(service.logController.value, isEmpty);
+    expect(snapshots, [
+      [stale],
+      isEmpty,
+    ]);
+  });
+
+  test("incoming logs publish immutable snapshots detached from the buffer", () async {
+    final incomingLogs = StreamController<LogMessage>();
+    addTearDown(incomingLogs.close);
+    final client = _FakeCoreClient(incomingLogs.stream);
+    final first = LogMessage(message: "first");
+    final second = LogMessage(message: "second");
+    final firstSnapshot = service.logController.stream.skip(1).first;
+
+    await service.startListeningLogs("test", client);
+    incomingLogs.add(first);
+
+    final published = await firstSnapshot.timeout(const Duration(seconds: 1));
+    incomingLogs.add(second);
+    await pumpEventQueue();
+
+    expect(published, [first]);
+    expect(() => published.add(second), throwsUnsupportedError);
+  });
+}
+
+class _FakeCoreClient extends CoreClient {
+  _FakeCoreClient(this.logs) : super(ClientChannel("localhost"));
+
+  final Stream<LogMessage> logs;
+
+  @override
+  ResponseStream<LogMessage> logListener(LogRequest request, {CallOptions? options}) {
+    return ResponseStream(_FakeClientCall(logs));
+  }
+}
+
+class _FakeClientCall<R> extends ClientCall<dynamic, R> {
+  _FakeClientCall(this.responses)
+    : super(
+        ClientMethod<dynamic, R>("/test", (_) => const [], (_) => throw UnimplementedError()),
+        const Stream.empty(),
+        CallOptions(),
+      );
+
+  final Stream<R> responses;
+
+  @override
+  Stream<R> get response => responses;
+
+  @override
+  Future<Map<String, String>> get headers async => const {};
+
+  @override
+  Future<Map<String, String>> get trailers async => const {};
+
+  @override
+  Future<void> cancel() async {}
+}


### PR DESCRIPTION
## Summary

- seed the log stream with an immutable empty snapshot so the Logs page can leave its loading state immediately
- use BehaviorSubject replay as the single initial emission, avoiding a duplicate empty snapshot
- keep subscriptions alive when created before Core initialization, allowing later gRPC log updates to reach existing listeners
- publish immutable snapshots when logs are appended or cleared

This is a narrower approach than #2126. It intentionally does not add file polling, synthesize timestamps from file data, or change the shared gRPC subscription error policy.

## Testing

- `flutter test --no-pub test/hiddifycore/hiddify_core_service_test.dart test/features/log/overview/logs_overview_notifier_test.dart` (7 tests)
- `flutter test --no-pub` (32 tests)
- `flutter analyze --no-pub` (reports the repository's existing analyzer baseline; no new production errors found)
- Fork Windows build: https://github.com/LiuLin1220/hiddify-app/actions/runs/31926156167
- [ ] Verify the Logs page while disconnected, after connecting, and after clearing logs

## References

This is a narrower, tested follow-up to #2126, which was closed unmerged by stale automation.