### PR TITLE
fix(profile): do not discard the whole profile when profile-title is malformed

### DIFF
--- a/lib/features/profile/data/profile_parser.dart
+++ b/lib/features/profile/data/profile_parser.dart
@@ -313,7 +313,13 @@ class ProfileParser {
 
         if (headers['profile-title'] case final String titleHeader when name.isEmpty) {
           if (titleHeader.startsWith("base64:")) {
-            name = utf8.decode(base64.decode(titleHeader.replaceFirst("base64:", "")));
+            try {
+              name = utf8.decode(base64.decode(titleHeader.replaceFirst("base64:", "")));
+            } on FormatException {
+              // `profile-title` is optional, so a payload that is not valid base64 or not valid
+              // UTF-8 must not fail the whole import. Leaving the name empty lets the documented
+              // fallback chain (content-disposition, url fragment, url filename, default) apply.
+            }
           } else {
             name = titleHeader.trim();
           }

--- a/test/features/profile/data/profile_parser_test.dart
+++ b/test/features/profile/data/profile_parser_test.dart
@@ -162,5 +162,68 @@ void main() {
         });
       });
     });
+    test("Should fall back to the name hierarchy when the base64 title is malformed", () {
+      final allHeaders = ProfileParser.populateHeaders(
+        content: '',
+        remoteHeaders: <String, dynamic>{"profile-title": "base64:not valid base64!!"},
+      );
+      expect(allHeaders.isRight(), true);
+      allHeaders.match((l) {}, (r) {
+        final profile = ProfileParser.parse(
+          tempFilePath: '',
+          profile: ProfileEntity.remote(
+            id: const Uuid().v4(),
+            active: true,
+            name: '',
+            url: validExtendedUrl,
+            lastUpdate: DateTime.now(),
+            populatedHeaders: r,
+          ),
+        );
+        expect(profile.isRight(), true);
+        profile.match((l) {}, (r) {
+          expect(r is RemoteProfileEntity, true);
+          r.map(
+            remote: (rp) {
+              // The url fragment, the next entry in the name hierarchy after profile-title.
+              expect(rp.name, equals("b"));
+            },
+            local: (lp) {},
+          );
+        });
+      });
+    });
+
+    test("Should fall back to the name hierarchy when the base64 title is not valid UTF-8", () {
+      final allHeaders = ProfileParser.populateHeaders(
+        content: '',
+        remoteHeaders: <String, dynamic>{"profile-title": "base64:/w=="},
+      );
+      expect(allHeaders.isRight(), true);
+      allHeaders.match((l) {}, (r) {
+        final profile = ProfileParser.parse(
+          tempFilePath: '',
+          profile: ProfileEntity.remote(
+            id: const Uuid().v4(),
+            active: true,
+            name: '',
+            url: validExtendedUrl,
+            lastUpdate: DateTime.now(),
+            populatedHeaders: r,
+          ),
+        );
+        expect(profile.isRight(), true);
+        profile.match((l) {}, (r) {
+          expect(r is RemoteProfileEntity, true);
+          r.map(
+            remote: (rp) {
+              // The url fragment, the next entry in the name hierarchy after profile-title.
+              expect(rp.name, equals("b"));
+            },
+            local: (lp) {},
+          );
+        });
+      });
+    });
   });
 }


### PR DESCRIPTION
Closes #2298.

## Problem

`profile-title` is an optional profile header, but `ProfileParser.parse()` decodes its `base64:` form without a guard:

```dart
if (titleHeader.startsWith("base64:")) {
  name = utf8.decode(base64.decode(titleHeader.replaceFirst("base64:", "")));
}
```

`base64.decode` raises `FormatException` on a malformed payload, and `utf8.decode` raises it when the decoded bytes are not valid UTF-8. Either one escapes to the enclosing `Either.tryCatch`, so the entire import fails with `ProfileFailure.unexpected` and the profile is discarded — even though the documented name hierarchy (`content-disposition`, url fragment, url filename, `Remote Profile`) would have produced a usable name.

Measured on `main` at 276a7ef:

- `base64:not valid base64!!` -> `FormatException: Invalid character (at character 4)` from `base64.decode`
- `base64:/w==` -> `FormatException: Invalid UTF-8 byte (at offset 0)` from `utf8.decode`

A subscription that emits one bad `profile-title` therefore cannot be imported at all, rather than being imported under a fallback name.

## Fix

Catch `FormatException` around the decode and leave the name empty, so the existing fallback chain continues. `base64.decode` and `utf8.decode` report malformed input exclusively through `FormatException`, so the catch covers that failure class without widening to `Error`; every other exception still reaches `Either.tryCatch` unchanged, and genuine failures are not masked.

## Tests

Two regression tests in `test/features/profile/data/profile_parser_test.dart`, one per failure mode. Both assert that the fallback was actually selected (`name == "b"`, the url fragment of the test url), not merely that nothing threw.

Local results, with Flutter 3.38.5 / Dart 3.10.4 matching `FLUTTER_VERSION` in `.github/workflows/build.yml`:

- unpatched `main` with these two tests added: 25 passed, 2 failed
- with this change: 27 passed
- `flutter analyze`: 246 issues before, 246 after

Supersedes #2299, which was cut from the wrong base and carried unrelated commits. This branch is cut from `main` and contains 1 commit, 2 files changed, 70 insertions(+), 1 deletion(-).
