### PR TITLE
fix(core): preserve background start failures

### DIFF
--- a/lib/hiddifycore/core_start_failure.dart
+++ b/lib/hiddifycore/core_start_failure.dart
@@ -1,0 +1,17 @@
+import 'package:grpc/grpc.dart';
+import 'package:hiddify/features/connection/model/connection_failure.dart';
+import 'package:hiddify/singbox/model/core_status.dart';
+
+({CoreStatus status, ConnectionFailure failure}) mapCoreStartGrpcError(GrpcError error) {
+  final grpcMessage = error.message?.trim();
+  final detail = [
+    'failed to start background core',
+    error.codeName,
+    if (grpcMessage != null && grpcMessage.isNotEmpty) grpcMessage,
+  ].join(': ');
+  final status = CoreStatus.stopped(alert: CoreAlert.startFailed, message: detail);
+  final failure = error.code == StatusCode.unavailable
+      ? ConnectionFailure.backgroundCoreNotAvailable(detail)
+      : ConnectionFailure.unexpected(detail);
+  return (status: status, failure: failure);
+}

--- a/lib/hiddifycore/hiddify_core_service.dart
+++ b/lib/hiddifycore/hiddify_core_service.dart
@@ -11,6 +11,7 @@ import 'package:hiddify/core/preferences/general_preferences.dart';
 import 'package:hiddify/features/connection/model/connection_failure.dart';
 import 'package:hiddify/features/settings/data/config_option_repository.dart';
 import 'package:hiddify/hiddifycore/core_interface/core_interface.dart';
+import 'package:hiddify/hiddifycore/core_start_failure.dart';
 import 'package:hiddify/hiddifycore/generated/v2/hcommon/common.pb.dart';
 import 'package:hiddify/hiddifycore/generated/v2/hcore/hcore.pb.dart';
 import 'package:hiddify/hiddifycore/generated/v2/hcore/hcore_service.pbgrpc.dart';
@@ -184,15 +185,10 @@ class HiddifyCoreService with InfraLogger {
         }
       } on GrpcError catch (e) {
         loggy.error("failed to start bg core: $e");
+        final (:status, :failure) = mapCoreStartGrpcError(e);
+        statusController.add(currentState = status);
         ref.read(coreRestartSignalProvider.notifier).restart();
-        if (e.code == StatusCode.unavailable) {
-          return left(const ConnectionFailure.unexpected("background core is not started yet!"));
-        }
-        // throw InvalidConfig(e.message);
-        // throw DioException.connectionError(requestOptions: RequestOptions(), reason: e.codeName, error: e);
-
-        // throw DioException(requestOptions: RequestOptions(), error: e);
-        return left(const ConnectionFailure.unexpected("failed to start background core"));
+        return left(failure);
       }
 
       // if (res.messageType != MessageType.EMPTY) return left(res);

--- a/test/hiddifycore/core_start_failure_test.dart
+++ b/test/hiddifycore/core_start_failure_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grpc/grpc.dart';
+import 'package:hiddify/features/connection/model/connection_failure.dart';
+import 'package:hiddify/hiddifycore/core_start_failure.dart';
+import 'package:hiddify/singbox/model/core_status.dart';
+
+void main() {
+  test('preserves gRPC details and publishes a stopped status', () {
+    final result = mapCoreStartGrpcError(
+      const GrpcError.unknown('start service: detour to an empty direct outbound makes no sense'),
+    );
+
+    const detail =
+        'failed to start background core: UNKNOWN: '
+        'start service: detour to an empty direct outbound makes no sense';
+    expect(result.status, const CoreStatus.stopped(alert: CoreAlert.startFailed, message: detail));
+    expect(result.failure, const ConnectionFailure.unexpected(detail));
+  });
+
+  test('classifies an unavailable Core separately', () {
+    final result = mapCoreStartGrpcError(const GrpcError.unavailable('connection refused'));
+
+    const detail = 'failed to start background core: UNAVAILABLE: connection refused';
+    expect(result.status, const CoreStatus.stopped(alert: CoreAlert.startFailed, message: detail));
+    expect(result.failure, const ConnectionFailure.backgroundCoreNotAvailable(detail));
+  });
+
+  test('does not add an empty message segment', () {
+    final result = mapCoreStartGrpcError(const GrpcError.unknown());
+
+    const detail = 'failed to start background core: UNKNOWN';
+    expect(result.status, const CoreStatus.stopped(alert: CoreAlert.startFailed, message: detail));
+    expect(result.failure, const ConnectionFailure.unexpected(detail));
+  });
+}


### PR DESCRIPTION
## Summary

- publish an explicit stopped status when a background Core start RPC fails
- preserve the gRPC status name and message instead of replacing every failure with `failed to start background core`
- classify an unavailable Core as `backgroundCoreNotAvailable` while retaining unexpected Core errors verbatim

The change is limited to App-side error propagation and connection state recovery. It does not change Core configuration generation, retry behavior, platform permissions, or service setup.

## Why

Different Core startup failures currently collapse into the same dialog, even though the original `GrpcError` contains the actionable cause. The catch path also returns before explicitly publishing a stopped status.

During Windows integration testing, the hidden error was:

```text
start service: start dns/tcp[dns-remote-no-warp]: detour to an empty direct outbound makes no sense
```

That Core configuration bug is addressed separately by hiddify/hiddify-core#146. Existing reports such as #2276, #2290, and #2291 demonstrate that the same generic App message also hides unrelated permission and platform failures; this PR improves their diagnostics but does not claim to fix each underlying cause.

## Testing

- `flutter test --no-pub test/hiddifycore/core_start_failure_test.dart` (3 tests)
- `flutter test --no-pub` (28 tests on this standalone branch)
- `flutter analyze --no-pub` (reports the repository baseline plus the existing `flutter_test` dependency info for the new test; no new production error)
- Combined fork Windows build and runtime validation: https://github.com/LiuLin1220/hiddify-app/actions/runs/32567872572

The combined Windows artifact also passed a real generated-config startup smoke test and an HTTP 204 request through the resulting local proxy.