### PR TITLE
fix: report the real cause when the background core fails to start

### DIFF
--- a/lib/hiddifycore/core_start_failure.dart
+++ b/lib/hiddifycore/core_start_failure.dart
@@ -1,0 +1,42 @@
+import 'package:hiddify/features/connection/model/connection_failure.dart';
+import 'package:hiddify/utils/platform_utils.dart';
+
+/// Fragments reported by the core (or by the OS underneath it) when the tunnel
+/// cannot be created because the process lacks the required privileges.
+///
+/// Linux and macOS surface `operation not permitted` while configuring the tun
+/// interface, Windows surfaces `access is denied` or an elevation requirement
+/// from the wintun driver, and mobile surfaces a denied VPN permission request.
+const List<String> privilegeErrorFragments = [
+  "operation not permitted",
+  "permission denied",
+  "access is denied",
+  "requires elevation",
+  "required privilege is not held",
+  "insufficient privileges",
+  "must be run as root",
+  "denied",
+];
+
+/// Whether [message] describes a failure caused by insufficient privileges.
+bool isPrivilegeError(String message) {
+  final normalized = message.toLowerCase();
+  return privilegeErrorFragments.any((fragment) => normalized.contains(fragment));
+}
+
+/// Maps a background core start failure onto a [ConnectionFailure] that keeps
+/// the original cause instead of collapsing every failure into one generic
+/// string.
+///
+/// Privilege failures become an actionable error: on desktop the tunnel needs
+/// administrator/root rights, on mobile it needs a VPN permission grant.
+ConnectionFailure backgroundCoreStartFailure(String message) {
+  if (isPrivilegeError(message)) {
+    return PlatformUtils.isDesktop
+        ? const ConnectionFailure.missingPrivilege()
+        : ConnectionFailure.missingVpnPermission(message);
+  }
+  return ConnectionFailure.unexpected(
+    message.isEmpty ? "failed to start background core" : "failed to start background core: $message",
+  );
+}

--- a/lib/hiddifycore/hiddify_core_service.dart
+++ b/lib/hiddifycore/hiddify_core_service.dart
@@ -11,6 +11,7 @@ import 'package:hiddify/core/preferences/general_preferences.dart';
 import 'package:hiddify/features/connection/model/connection_failure.dart';
 import 'package:hiddify/features/settings/data/config_option_repository.dart';
 import 'package:hiddify/hiddifycore/core_interface/core_interface.dart';
+import 'package:hiddify/hiddifycore/core_start_failure.dart';
 import 'package:hiddify/hiddifycore/generated/v2/hcommon/common.pb.dart';
 import 'package:hiddify/hiddifycore/generated/v2/hcore/hcore.pb.dart';
 import 'package:hiddify/hiddifycore/generated/v2/hcore/hcore_service.pbgrpc.dart';
@@ -169,7 +170,7 @@ class HiddifyCoreService with InfraLogger {
         );
         ref.read(coreRestartSignalProvider.notifier).restart();
         if (res.messageType != MessageType.ALREADY_STARTED && res.messageType != MessageType.EMPTY) {
-          final alert = res.message.contains("denied") ? CoreAlert.requestVPNPermission : CoreAlert.startFailed;
+          final alert = isPrivilegeError(res.message) ? CoreAlert.requestVPNPermission : CoreAlert.startFailed;
           currentState = CoreStatus.stopped(
             alert: alert,
             message: "failed to start core ${res.messageType} ${res.message}",
@@ -188,11 +189,7 @@ class HiddifyCoreService with InfraLogger {
         if (e.code == StatusCode.unavailable) {
           return left(const ConnectionFailure.unexpected("background core is not started yet!"));
         }
-        // throw InvalidConfig(e.message);
-        // throw DioException.connectionError(requestOptions: RequestOptions(), reason: e.codeName, error: e);
-
-        // throw DioException(requestOptions: RequestOptions(), error: e);
-        return left(const ConnectionFailure.unexpected("failed to start background core"));
+        return left(backgroundCoreStartFailure(e.message ?? ""));
       }
 
       // if (res.messageType != MessageType.EMPTY) return left(res);

--- a/lib/singbox/model/core_status.dart
+++ b/lib/singbox/model/core_status.dart
@@ -2,6 +2,7 @@ import 'package:dartx/dartx.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:hiddify/features/connection/model/connection_failure.dart';
 import 'package:hiddify/hiddifycore/generated/v2/hcore/hcore.pb.dart';
+import 'package:hiddify/utils/platform_utils.dart';
 
 part 'core_status.freezed.dart';
 
@@ -79,7 +80,11 @@ sealed class CoreStatus with _$CoreStatus {
 
         CoreAlert.requestNotificationPermission => ConnectionFailure.missingNotificationPermission(message),
 
-        CoreAlert.requestVPNPermission => ConnectionFailure.missingVpnPermission(message),
+        // On desktop the tunnel needs administrator/root rights rather than a
+        // VPN permission grant, so report the actionable privilege error instead.
+        CoreAlert.requestVPNPermission => PlatformUtils.isDesktop
+            ? const ConnectionFailure.missingPrivilege()
+            : ConnectionFailure.missingVpnPermission(message),
 
         CoreAlert.startCommandServer ||
         CoreAlert.createService ||

--- a/test/hiddifycore/core_start_failure_test.dart
+++ b/test/hiddifycore/core_start_failure_test.dart
@@ -1,0 +1,47 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:hiddify/features/connection/model/connection_failure.dart";
+import "package:hiddify/hiddifycore/core_start_failure.dart";
+import "package:hiddify/utils/platform_utils.dart";
+
+void main() {
+  group("isPrivilegeError", () {
+    test("detects the tun permission errors reported by the core", () {
+      expect(
+        isPrivilegeError("manager start inbound/tun[tun-in]: configure tun interface: operation not permitted"),
+        isTrue,
+      );
+      expect(isPrivilegeError("CreateFile failed: Access is denied."), isTrue);
+      expect(isPrivilegeError("permission denied"), isTrue);
+      // Windows ERROR_PRIVILEGE_NOT_HELD (1314), raised by wintun without elevation.
+      expect(isPrivilegeError("A required privilege is not held by the client."), isTrue);
+    });
+
+    test("does not flag unrelated failures", () {
+      expect(isPrivilegeError("dial tcp 1.2.3.4:443: i/o timeout"), isFalse);
+      expect(isPrivilegeError("decode config at index 0: invalid character"), isFalse);
+      expect(isPrivilegeError(""), isFalse);
+    });
+  });
+
+  group("backgroundCoreStartFailure", () {
+    test("keeps the original cause for unrelated failures", () {
+      expect(
+        backgroundCoreStartFailure("address already in use"),
+        isA<UnexpectedConnectionFailure>().having((f) => f.error, "error", contains("address already in use")),
+      );
+    });
+
+    test("falls back to the generic message when the core reports nothing", () {
+      expect(backgroundCoreStartFailure(""), isA<UnexpectedConnectionFailure>());
+    });
+
+    test("reports privilege failures as an actionable error", () {
+      // `flutter test` runs on a desktop host, where the tunnel needs elevation.
+      expect(PlatformUtils.isDesktop, isTrue);
+      expect(
+        backgroundCoreStartFailure("configure tun interface: operation not permitted"),
+        isA<MissingPrivilege>(),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Every gRPC failure while starting the background core is replaced with the constant string `"failed to start background core"`, discarding the message that says what actually went wrong:

```dart
} on GrpcError catch (e) {
  ...
  return left(const ConnectionFailure.unexpected("failed to start background core"));
}
```

The most common cause on desktop is that the tun interface cannot be created without elevation — `configure tun interface: operation not permitted` on Linux/macOS, `Access is denied.` / `A required privilege is not held by the client.` from wintun on Windows. The user sees a generic error with no hint that relaunching as administrator/root fixes it, so the same report keeps coming back: #2224, #2276, #1936, #2083, #2290, #2270, #2291, #1983, #2103, #1956.

In #2224 the reporter got no answer for a month; the eventual community fix was simply "start Hiddify as administrator", confirmed by another user. The app could have said that itself.

## The message already exists — it is just unreachable

`assets/translations/` ships this in 15+ languages:

> **Missing privilege** — "VPN mode requires administrator privileges. Either relaunch the app as administrator or change service mode."

It is wired up in `ConnectionFailure.present()`, but **`ConnectionFailure.missingPrivilege()` is never constructed anywhere in `lib/`** — the only two references are its declaration and its render arm. The translation has never been shown to a single user.

## Changes

- Add `lib/hiddifycore/core_start_failure.dart`, which classifies a core start error and maps privilege failures to `missingPrivilege()` on desktop (mobile keeps `missingVpnPermission`, where a VPN grant really is what is missing).
- Keep the original message for every other failure instead of replacing it with a constant, so unrelated causes stay diagnosable from the UI.
- Widen the check on the response path: it only matched `"denied"`, so it missed `operation not permitted` entirely.
- Make `CoreAlert.requestVPNPermission` platform-aware in `core_status.dart` — on desktop the tunnel needs admin/root, not a VPN permission grant.
- Add unit tests, including the Windows `ERROR_PRIVILEGE_NOT_HELD (1314)` wording, which contains neither "denied" nor "not permitted".

## Scope

This only makes the failure actionable. It deliberately does **not** change how the app acquires privileges (manifest `requestedExecutionLevel`, or a helper service) — that is an architectural decision and per CONTRIBUTING belongs in an issue discussion first. Happy to open one if you would like to go that way.

## Verification

Run locally against the toolchain pinned in `build.yml` (Flutter 3.38.5):

- `dart run slang` + `dart run build_runner build --delete-conflicting-outputs` — clean
- `flutter test` — **30/30 passing** (25 existing + 5 new)
- `flutter analyze` on the changed files — **no new issues**; `hiddify_core_service.dart` still reports exactly the 11 pre-existing warnings it has on `main`, and the two new/changed files report none
