### PR TITLE
fix: expose profile-web-page-url / support-url in the profile UI

### DIFF
--- a/lib/features/profile/widget/profile_tile.dart
+++ b/lib/features/profile/widget/profile_tile.dart
@@ -405,36 +405,34 @@ class ProfileLinksRow extends HookConsumerWidget {
     final t = ref.watch(translationsProvider).requireValue;
     final theme = Theme.of(context);
 
-    Widget buildLink(IconData icon, String label, String url) => Expanded(
-      child: InkWell(
-        borderRadius: BorderRadius.circular(8),
-        onTap: () => _launchProfileLink(context, ref, url),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 4),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(icon, size: 16, color: theme.colorScheme.primary),
-              const Gap(4),
-              Flexible(
-                child: Text(
-                  label,
-                  style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.primary),
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-            ],
-          ),
+    Widget buildChip(IconData icon, String label, String url) => InkWell(
+      borderRadius: BorderRadius.circular(20),
+      onTap: () => _launchProfileLink(context, ref, url),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.primaryContainer.withOpacity(0.4),
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(label, style: theme.textTheme.labelMedium?.copyWith(color: theme.colorScheme.primary)),
+            const Gap(6),
+            Icon(icon, size: 14, color: theme.colorScheme.primary),
+          ],
         ),
       ),
     );
 
-    return Row(
+    return Wrap(
+      spacing: 8,
+      runSpacing: 4,
       children: [
         if (subInfo.webPageUrl != null)
-          buildLink(FluentIcons.globe_24_regular, t.components.subscriptionInfo.profileSite, subInfo.webPageUrl!),
+          buildChip(FluentIcons.open_24_regular, t.components.subscriptionInfo.profileSite, subInfo.webPageUrl!),
         if (subInfo.supportUrl != null)
-          buildLink(FluentIcons.chat_help_24_regular, t.components.subscriptionInfo.profileSupport, subInfo.supportUrl!),
+          buildChip(FluentIcons.open_24_regular, t.components.subscriptionInfo.profileSupport, subInfo.supportUrl!),
       ],
     );
   }

--- a/lib/features/profile/widget/profile_tile.dart
+++ b/lib/features/profile/widget/profile_tile.dart
@@ -284,6 +284,20 @@ class ProfileActionsMenu extends HookConsumerWidget {
           ),
         ],
       ),
+      if (profile case RemoteProfileEntity(:final subInfo?)) ...[
+        if (subInfo.webPageUrl != null)
+          AdaptiveMenuItem(
+            leadingIcon: const Icon(FluentIcons.globe_24_regular),
+            title: t.components.subscriptionInfo.profileSite,
+            onTap: () => _launchProfileLink(context, ref, subInfo.webPageUrl!),
+          ),
+        if (subInfo.supportUrl != null)
+          AdaptiveMenuItem(
+            leadingIcon: const Icon(FluentIcons.chat_help_24_regular),
+            title: t.components.subscriptionInfo.profileSupport,
+            onTap: () => _launchProfileLink(context, ref, subInfo.supportUrl!),
+          ),
+      ],
       AdaptiveMenuItem(
         leadingIcon: const Icon(Icons.edit_rounded),
         title: t.common.edit,
@@ -310,6 +324,16 @@ class ProfileActionsMenu extends HookConsumerWidget {
     ];
 
     return AdaptiveMenu(builder: builder, items: menuItems, child: child);
+  }
+
+  // profile-supplied urls are untrusted, so confirm with the user before opening them
+  Future<void> _launchProfileLink(BuildContext context, WidgetRef ref, String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    final shouldLaunch = await ref.read(dialogNotifierProvider.notifier).showUnknownDomainsWarning(url: url);
+    if (shouldLaunch && context.mounted) {
+      await launchUrl(uri);
+    }
   }
 }
 

--- a/lib/features/profile/widget/profile_tile.dart
+++ b/lib/features/profile/widget/profile_tile.dart
@@ -22,6 +22,16 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'package:url_launcher/url_launcher.dart';
 
+// profile-supplied urls are untrusted, so confirm with the user before opening them
+Future<void> _launchProfileLink(BuildContext context, WidgetRef ref, String url) async {
+  final uri = Uri.tryParse(url);
+  if (uri == null) return;
+  final shouldLaunch = await ref.read(dialogNotifierProvider.notifier).showUnknownDomainsWarning(url: url);
+  if (shouldLaunch && context.mounted) {
+    await launchUrl(uri);
+  }
+}
+
 class ProfileTile extends HookConsumerWidget {
   const ProfileTile({super.key, required this.profile, this.isMain = false, this.margin = EdgeInsets.zero, this.color});
 
@@ -164,6 +174,8 @@ class ProfileTile extends HookConsumerWidget {
                             const Gap(4),
                             ProfileSubscriptionInfo(subInfo),
                             const Gap(4),
+                            if (isMain && (subInfo.webPageUrl != null || subInfo.supportUrl != null))
+                              ProfileLinksRow(subInfo),
                           ],
                         ],
                       ),
@@ -325,19 +337,8 @@ class ProfileActionsMenu extends HookConsumerWidget {
 
     return AdaptiveMenu(builder: builder, items: menuItems, child: child);
   }
-
-  // profile-supplied urls are untrusted, so confirm with the user before opening them
-  Future<void> _launchProfileLink(BuildContext context, WidgetRef ref, String url) async {
-    final uri = Uri.tryParse(url);
-    if (uri == null) return;
-    final shouldLaunch = await ref.read(dialogNotifierProvider.notifier).showUnknownDomainsWarning(url: url);
-    if (shouldLaunch && context.mounted) {
-      await launchUrl(uri);
-    }
-  }
 }
 
-// TODO add support url
 class ProfileSubscriptionInfo extends HookConsumerWidget {
   const ProfileSubscriptionInfo(this.subInfo, {super.key});
 
@@ -389,6 +390,51 @@ class ProfileSubscriptionInfo extends HookConsumerWidget {
             overflow: TextOverflow.ellipsis,
           ),
         ),
+      ],
+    );
+  }
+}
+
+class ProfileLinksRow extends HookConsumerWidget {
+  const ProfileLinksRow(this.subInfo, {super.key});
+
+  final SubscriptionInfo subInfo;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final t = ref.watch(translationsProvider).requireValue;
+    final theme = Theme.of(context);
+
+    Widget buildLink(IconData icon, String label, String url) => Expanded(
+      child: InkWell(
+        borderRadius: BorderRadius.circular(8),
+        onTap: () => _launchProfileLink(context, ref, url),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, size: 16, color: theme.colorScheme.primary),
+              const Gap(4),
+              Flexible(
+                child: Text(
+                  label,
+                  style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.primary),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    return Row(
+      children: [
+        if (subInfo.webPageUrl != null)
+          buildLink(FluentIcons.globe_24_regular, t.components.subscriptionInfo.profileSite, subInfo.webPageUrl!),
+        if (subInfo.supportUrl != null)
+          buildLink(FluentIcons.chat_help_24_regular, t.components.subscriptionInfo.profileSupport, subInfo.supportUrl!),
       ],
     );
   }


### PR DESCRIPTION
`profile-web-page-url` and `support-url` headers were already parsed and stored (`ProfileParser`, `SubscriptionInfo`), but nothing in the UI rendered them

<img width="1078" height="513" alt="Screenshot_20260905-101316-edited" src="https://github.com/user-attachments/assets/876aa0d6-0dbc-4b74-a14b-ad5b798bd304" />
<img width="1078" height="2174" alt="Screenshot_20260905-101321-edited" src="https://github.com/user-attachments/assets/c6f2048a-16b5-49ea-9bca-3c2e4cf35a4f" />

fixes #2063
fixes #1722